### PR TITLE
Added experimental iterative implementation

### DIFF
--- a/saxbospiral.c
+++ b/saxbospiral.c
@@ -202,11 +202,11 @@ spiral_collides(spiral_t spiral) {
 
 // private function, given a spiral struct, the index of one of it's lines and
 // a target length to set that line to, attempt to set the target line to that
-// length, recursively calling self to resize the previous line if that is not
-// possible.
+// length, back-tacking to resize the previous line if it collides.
 static spiral_t
 resize_spiral(spiral_t spiral, size_t index, uint32_t length) {
-    // setup state variables
+    // setup state variables, these are used in place of recursion for managing
+    // state of which line is being resized, and what size it should be.
     size_t current_index = index;
     size_t current_length = length;
     while(true) {
@@ -220,12 +220,19 @@ resize_spiral(spiral_t spiral, size_t index, uint32_t length) {
         // update the spiral's co-ord cache
         cache_spiral_points(&spiral, current_index + 1);
         if(spiral_collides(spiral)) {
+            // if we've caused a collision, we should back-track
+            // and increase the size of the previous line segment
             current_index--;
             current_length = spiral.lines[current_index].length + 1;
         } else if(current_index != index) {
+            // if we didn't cause a collision but we're not on the top-most
+            // line, then we've just resolved a collision situation.
+            // we now need to work on the next line and start by setting to 1.
             current_index++;
             current_length = 1;
         } else {
+            // if we're on the top-most line and there's no collision
+            // this means we've finished! Return result.
             return spiral;
         }
     }


### PR DESCRIPTION
Turns out this doesn't stop out of memory problems, and I have discovered this is caused by a memory leak somewhere else instead!

However, I think this may well be more efficient due to the (minuscule but still present) overhead of stack frames being allocated for each recursive call. I will investigate this further before incorporating this work.
