### PR TITLE
Remove forced shared library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ file(
     GLOB LIB_SAXBOSPIRAL_RENDER_BACKENDS_HEADERS
     "saxbospiral/render_backends/*.h"
 )
-add_library(saxbospiral SHARED ${LIB_SAXBOSPIRAL_SOURCES})
+add_library(saxbospiral ${LIB_SAXBOSPIRAL_SOURCES})
 # Link libsaxbospiral with libpng so we get libpng symbols
 target_link_libraries(saxbospiral ${PNG_LIBRARY})
 


### PR DESCRIPTION
This allows the user to specify whether they would like a shared or static library
(shared by default in most environments)
