### PR TITLE
File Format Version Freeze

### DIFF
--- a/saxbospiral/saxbospiral.c
+++ b/saxbospiral/saxbospiral.c
@@ -12,6 +12,14 @@ const version_t VERSION = {
     .patch = SAXBOSPIRAL_VERSION_PATCH,
 };
 
+/*
+ * computes a version_hash_t for a given version_t,
+ * to be used for indexing and ordering
+ */
+version_hash_t version_hash(version_t version) {
+    return (version.major * 65536) + (version.minor * 256) + version.patch;
+}
+
 // vector direction constants
 const vector_t VECTOR_DIRECTIONS[4] = {
     // UP       RIGHT       DOWN        LEFT

--- a/saxbospiral/saxbospiral.h
+++ b/saxbospiral/saxbospiral.h
@@ -22,6 +22,15 @@ typedef struct version_t {
 
 extern const version_t VERSION;
 
+// used for indexing and comparing different versions in order
+typedef uint32_t version_hash_t;
+
+/*
+ * computes a version_hash_t for a given version_t,
+ * to be used for indexing and ordering
+ */
+version_hash_t version_hash(version_t version);
+
 // type for representing a cartesian direction
 typedef uint8_t direction_t;
 

--- a/saxbospiral/serialise.c
+++ b/saxbospiral/serialise.c
@@ -35,13 +35,20 @@ load_spiral(buffer_t buffer) {
         (strncmp((char *)buffer.bytes, "SAXBOSPIRAL", 11) == 0)
         && (buffer.size >= FILE_HEADER_SIZE + LINE_T_PACK_SIZE)
     ) {
-        // good to go
-        // TODO: Add checks for buffer data version compatibility
-        /*
-        version_t data_version = {
-            buffer.bytes[12], buffer.bytes[13], buffer.bytes[13],
+        // grab file version from header
+        version_t buffer_version = {
+            .major = buffer.bytes[12],
+            .minor = buffer.bytes[13],
+            .patch = buffer.bytes[14],
         };
-        */
+        // we don't accept anything over v0.11.x, so the max is v0.11.255
+        version_t max_version = { .major = 0, .minor = 11, .patch = 255, };
+        // check for version compatibility
+        if(version_hash(buffer_version) > version_hash(max_version)) {
+            // check failed
+            return output;
+        }
+        // good to go
         // get size of spiral object contained in buffer
         size_t spiral_size = 0;
         for(size_t i = 0; i < 8; i++) {

--- a/sxp.c
+++ b/sxp.c
@@ -130,6 +130,14 @@ run(
     } else if(generate) {
         // try and load a spiral struct from input file
         spiral_t spiral = load_spiral(input_buffer);
+        // the spiral size will be set to 0 if buffer data was invalid
+        if(spiral.size == 0) {
+            fprintf(
+                stderr, "ERROR - File data was invalid (not a format accepted "
+                "by SAXBOSPIRAL " SAXBOSPIRAL_VERSION_STRING ")\n"
+            );
+            return false;
+        }
         // we must plot all lines from spiral file
         spiral = plot_spiral(spiral, perfection);
         // dump spiral


### PR DESCRIPTION
- Froze the version of the file format, versions of SXP in the **v0.11.x** range will refuse to load files with a version above **v0.11.255**. This is in preparation for changing the file format, which is planned to happen at **v0.12.0**.
- Added computing of hashes for versions, and checking this when loading files
