### PR TITLE
Fix clang warnings / errors

### DIFF
--- a/saxbospiral/plot.c
+++ b/saxbospiral/plot.c
@@ -35,7 +35,7 @@ spiral_points(
     size_t start, size_t end
 ) {
     // prepare result status
-    status_t result = {0};
+    status_t result = {{0, 0, 0}, 0};
     // the amount of space needed is the sum of all line lengths + 1 for end
     size_t size = sum_lines(spiral, start, end) + 1;
     // allocate memory
@@ -82,7 +82,7 @@ spiral_points(
 status_t
 cache_spiral_points(spiral_t * spiral, size_t limit) {
     // prepare result status
-    status_t result = {0};
+    status_t result = {{0, 0, 0}, 0};
     // the amount of space needed is the sum of all line lengths + 1 for end
     size_t size = sum_lines(*spiral, 0, limit) + 1;
     // allocate / reallocate memory
@@ -126,7 +126,7 @@ cache_spiral_points(spiral_t * spiral, size_t limit) {
         spiral->co_ord_cache.co_ords.items[0] = current;
     }
     // calculate the missing co-ords
-    co_ord_array_t missing= {0};
+    co_ord_array_t missing= {0, 0};
     status_t calculate_result = spiral_points(
         *spiral, &missing, current, smallest, limit
     );

--- a/saxbospiral/render.c
+++ b/saxbospiral/render.c
@@ -58,11 +58,11 @@ get_bounds(spiral_t spiral, co_ord_t * bounds) {
 status_t
 render_spiral(spiral_t spiral, bitmap_t * image) {
     // create result status struct
-    status_t result = {0};
+    status_t result = {{0, 0, 0}, 0};
     // plot co-ords of spiral into it's cache
     cache_spiral_points(&spiral, spiral.size);
     // get the min and max bounds of the spiral's co-ords
-    co_ord_t bounds[2] = {0};
+    co_ord_t bounds[2] = {{0, 0}};
     get_bounds(spiral, bounds);
     // get the normalisation vector needed to make all values unsigned
     tuple_t normalisation_vector = {

--- a/saxbospiral/solve.c
+++ b/saxbospiral/solve.c
@@ -184,7 +184,7 @@ resize_spiral(
      * state of which line is being resized, and what size it should be.
      */
     // set result status
-    status_t result = {0};
+    status_t result = {{0, 0, 0}, 0};
     size_t current_index = index;
     length_t current_length = length;
     while(true) {
@@ -244,7 +244,7 @@ resize_spiral(
 status_t
 plot_spiral(spiral_t * spiral, int perfection_threshold) {
     // set up result status
-    status_t result = {0};
+    status_t result = {{0, 0, 0}, 0};
     // calculate the length of each line
     for(size_t i = 0; i < spiral->size; i++) {
         result = resize_spiral(spiral, i, 1, perfection_threshold);

--- a/sxp.c
+++ b/sxp.c
@@ -157,9 +157,9 @@ run(
         return false;
     }
     // make input buffer
-    buffer_t input_buffer = {0};
+    buffer_t input_buffer = {0, 0};
     // make output buffer
-    buffer_t output_buffer = {0};
+    buffer_t output_buffer = {0, 0};
     // read input file into buffer
     bool read_ok = file_to_buffer(input_file, &input_buffer);
     // used later for telling if write of output file was success
@@ -172,7 +172,7 @@ run(
         return false;
     }
     // create initial blank spiral struct
-    spiral_t spiral = {0};
+    spiral_t spiral = {0, 0, {{0, 0}, 0}, 0};
     // resolve perfection threshold - set to -1 if disabled completely
     int perfection = (perfect == false) ? -1 : perfect_threshold;
     // check error condition (where no actions were specified)
@@ -212,7 +212,7 @@ run(
     }
     if(render) {
         // we must render an image from spiral
-        bitmap_t image = {0};
+        bitmap_t image = {0, 0, 0};
         if(handle_error(render_spiral(spiral, &image))) {
             // handle errors
             return false;

--- a/tests.c
+++ b/tests.c
@@ -105,7 +105,7 @@ test_spiral_points() {
     };
 
     // create struct for results
-    co_ord_array_t results = {0};
+    co_ord_array_t results = {0, 0};
     // call spiral_points on struct with start point and maximum limit
     spiral_points(input, &results, expected[0], 0, 16);
 


### PR DESCRIPTION
Address all warnings issued by clang about missing initialisers
This is necessary because I've enabled an option to convert all warnings to errors for this project.
