### PR TITLE
Reformat all function prototypes to have return type on same line

### DIFF
--- a/saxbospiral/initialise.c
+++ b/saxbospiral/initialise.c
@@ -13,8 +13,7 @@ extern "C"{
  * when facing the direction specified by current, return the direction that
  * will be faced when turning in the rotational direction specified by turn.
  */
-direction_t
-change_direction(direction_t current, rotation_t turn) {
+direction_t change_direction(direction_t current, rotation_t turn) {
     return (current + turn) % 4U;
 }
 
@@ -25,8 +24,7 @@ change_direction(direction_t current, rotation_t turn) {
  * instructions which are then used to build the pattern.
  * returns a status_t struct with error information (if needed)
  */
-status_t
-init_spiral(buffer_t buffer, spiral_t * spiral) {
+status_t init_spiral(buffer_t buffer, spiral_t * spiral) {
     // result status object
     status_t result;
     // number of lines is number of bits of the data, + 1 for the first UP line

--- a/saxbospiral/initialise.h
+++ b/saxbospiral/initialise.h
@@ -12,8 +12,7 @@ extern "C"{
  * when facing the direction specified by current, return the direction that
  * will be faced when turning in the rotational direction specified by turn.
  */
-direction_t
-change_direction(direction_t current, rotation_t turn);
+direction_t change_direction(direction_t current, rotation_t turn);
 
 /*
  * given a buffer_t full of data, and a pointer to a blank spiral_t
@@ -22,8 +21,7 @@ change_direction(direction_t current, rotation_t turn);
  * instructions which are then used to build the pattern.
  * returns a status_t struct with error information (if needed)
  */
-status_t
-init_spiral(buffer_t buffer, spiral_t * spiral);
+status_t init_spiral(buffer_t buffer, spiral_t * spiral);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/saxbospiral/plot.c
+++ b/saxbospiral/plot.c
@@ -10,8 +10,7 @@ extern "C"{
 #endif
 
 // returns the sum of all line lengths within the given indexes
-size_t
-sum_lines(spiral_t spiral, size_t start, size_t end) {
+size_t sum_lines(spiral_t spiral, size_t start, size_t end) {
     size_t size = 0;
     for(size_t i = start; i < end; i++) {
         size += spiral.lines[i].length;
@@ -29,8 +28,7 @@ sum_lines(spiral_t spiral, size_t start, size_t end) {
  * lines longer than one unit.
  * returns a status struct with error information (if any)
  */
-status_t
-spiral_points(
+status_t spiral_points(
     spiral_t spiral, co_ord_array_t * output, co_ord_t start_point,
     size_t start, size_t end
 ) {
@@ -79,8 +77,7 @@ spiral_points(
  * member and are re-used if they are still valid
  * returns a status struct with error information (if any)
  */
-status_t
-cache_spiral_points(spiral_t * spiral, size_t limit) {
+status_t cache_spiral_points(spiral_t * spiral, size_t limit) {
     // prepare result status
     status_t result = {{0, 0, 0}, 0};
     // the amount of space needed is the sum of all line lengths + 1 for end

--- a/saxbospiral/plot.h
+++ b/saxbospiral/plot.h
@@ -11,8 +11,7 @@ extern "C"{
 #endif
 
 // returns the sum of all line lengths within the given indexes
-size_t
-sum_lines(spiral_t spiral, size_t start, size_t end);
+size_t sum_lines(spiral_t spiral, size_t start, size_t end);
 
 /*
  * given a spiral_t struct, a pointer to a co_ord_array_t, a pair of co-ords
@@ -24,8 +23,7 @@ sum_lines(spiral_t spiral, size_t start, size_t end);
  * lines longer than one unit.
  * returns a status struct with error information (if any)
  */
-status_t
-spiral_points(
+status_t spiral_points(
     spiral_t spiral, co_ord_array_t * output, co_ord_t start_point,
     size_t start, size_t end
 );
@@ -39,8 +37,7 @@ spiral_points(
  * member and are re-used if they are still valid
  * returns a status struct with error information (if any)
  */
-status_t
-cache_spiral_points(spiral_t * spiral, size_t limit);
+status_t cache_spiral_points(spiral_t * spiral, size_t limit);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/saxbospiral/render.c
+++ b/saxbospiral/render.c
@@ -23,8 +23,7 @@ extern "C"{
  * NOTE: This should NEVER be called with a pointer to anything other than a
  * 2-item struct of type co_ord_t
  */
-static void
-get_bounds(spiral_t spiral, co_ord_t * bounds) {
+static void get_bounds(spiral_t spiral, co_ord_t * bounds) {
     tuple_item_t min_x = 0;
     tuple_item_t min_y = 0;
     tuple_item_t max_x = 0;
@@ -55,8 +54,7 @@ get_bounds(spiral_t spiral, co_ord_t * bounds) {
  * representing a monochromatic image of the rendered spiral to the bitmap
  * returns a status struct with error information (if any)
  */
-status_t
-render_spiral(spiral_t spiral, bitmap_t * image) {
+status_t render_spiral(spiral_t spiral, bitmap_t * image) {
     // create result status struct
     status_t result = {{0, 0, 0}, 0};
     // plot co-ords of spiral into it's cache

--- a/saxbospiral/render.h
+++ b/saxbospiral/render.h
@@ -27,8 +27,7 @@ typedef struct bitmap_t {
  * representing a monochromatic image of the rendered spiral to the bitmap
  * returns a status struct with error information (if any)
  */
-status_t
-render_spiral(spiral_t spiral, bitmap_t * image);
+status_t render_spiral(spiral_t spiral, bitmap_t * image);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/saxbospiral/render_backends/png_backend.c
+++ b/saxbospiral/render_backends/png_backend.c
@@ -13,8 +13,9 @@ extern "C"{
 #endif
 
 // private custom libPNG buffer write function
-static void
-buffer_write_data(png_structp png_ptr, png_bytep data, png_size_t length) {
+static void buffer_write_data(
+    png_structp png_ptr, png_bytep data, png_size_t length
+) {
     // retrieve pointer to buffer
     buffer_t * p = (buffer_t *)png_get_io_ptr(png_ptr);
     size_t new_size = p->size + length;
@@ -43,8 +44,7 @@ void dummy_png_flush(png_structp png_ptr) {}
 #pragma GCC diagnostic pop
 
 // simple libpng cleanup function - used mainly for freeing memory
-void
-cleanup_png_lib(png_structp png_ptr, png_infop info_ptr, png_bytep row) {
+void cleanup_png_lib(png_structp png_ptr, png_infop info_ptr, png_bytep row) {
     if (info_ptr != NULL) png_free_data(png_ptr, info_ptr, PNG_FREE_ALL, -1);
     if (png_ptr != NULL) png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
     if (row != NULL) free(row);
@@ -55,8 +55,7 @@ cleanup_png_lib(png_structp png_ptr, png_infop info_ptr, png_bytep row) {
  * data as a PNG image to the buffer, using libpng.
  * returns a status struct containing error information, if any
  */
-status_t
-write_png_image(bitmap_t bitmap, buffer_t * buffer) {
+status_t write_png_image(bitmap_t bitmap, buffer_t * buffer) {
     // result status
     status_t result;
     // init buffer

--- a/saxbospiral/render_backends/png_backend.h
+++ b/saxbospiral/render_backends/png_backend.h
@@ -14,8 +14,7 @@ extern "C"{
  * data as a PNG image to the buffer, using libpng.
  * returns a status struct containing error information, if any
  */
-status_t
-write_png_image(bitmap_t bitmap, buffer_t * buffer);
+status_t write_png_image(bitmap_t bitmap, buffer_t * buffer);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/saxbospiral/serialise.c
+++ b/saxbospiral/serialise.c
@@ -26,8 +26,7 @@ const size_t LINE_T_PACK_SIZE = 4;
  * whether the operation was successful or not and information about what went
  * wrong if it was not successful
  */
-serialise_result_t
-load_spiral(buffer_t buffer, spiral_t * spiral) {
+serialise_result_t load_spiral(buffer_t buffer, spiral_t * spiral) {
     serialise_result_t result; // build struct for returning success / failure
     // first, if header is too small for header + 1 line, then return early
     if(buffer.size < FILE_HEADER_SIZE + LINE_T_PACK_SIZE) {
@@ -117,8 +116,7 @@ load_spiral(buffer_t buffer, spiral_t * spiral) {
  * whether the operation was successful or not and information about what went
  * wrong if it was not successful
  */
-serialise_result_t
-dump_spiral(spiral_t spiral, buffer_t * buffer) {
+serialise_result_t dump_spiral(spiral_t spiral, buffer_t * buffer) {
     serialise_result_t result; // build struct for returning success / failure
     // populate buffer struct, base size on header + spiral size
     buffer->size = (FILE_HEADER_SIZE + (LINE_T_PACK_SIZE * spiral.size));

--- a/saxbospiral/serialise.h
+++ b/saxbospiral/serialise.h
@@ -39,8 +39,7 @@ extern const size_t LINE_T_PACK_SIZE;
  * whether the operation was successful or not and information about what went
  * wrong if it was not successful
  */
-serialise_result_t
-load_spiral(buffer_t buffer, spiral_t * spiral);
+serialise_result_t load_spiral(buffer_t buffer, spiral_t * spiral);
 
 /*
  * given a spiral_t struct and a pointer to a blank buffer_t, serialise a binary
@@ -49,8 +48,7 @@ load_spiral(buffer_t buffer, spiral_t * spiral);
  * whether the operation was successful or not and information about what went
  * wrong if it was not successful
  */
-serialise_result_t
-dump_spiral(spiral_t spiral, buffer_t * buffer);
+serialise_result_t dump_spiral(spiral_t spiral, buffer_t * buffer);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/saxbospiral/solve.c
+++ b/saxbospiral/solve.c
@@ -26,8 +26,7 @@ extern "C"{
  * Returns the index of the lowest line that the latest line collided with if
  * there are collisions, or -1 if no collisions were found.
  */
-static int64_t
-spiral_collides(spiral_t spiral, size_t index) {
+static int64_t spiral_collides(spiral_t spiral, size_t index) {
     /*
      * if there are less than 4 lines in the spiral, then there's no way it
      * can collide, so return -1 early
@@ -95,8 +94,9 @@ spiral_collides(spiral_t spiral, size_t index) {
  * the newly plotted line has collided with and 'previous' or 'p' refers to the
  * line before the newly plotted line.
  */
-static length_t
-suggest_resize(spiral_t spiral, size_t index, int perfection_threshold) {
+static length_t suggest_resize(
+    spiral_t spiral, size_t index, int perfection_threshold
+) {
     // check if collides or not, return same size if no collision
     if(spiral.collides != -1) {
         /*
@@ -175,8 +175,7 @@ suggest_resize(spiral_t spiral, size_t index, int perfection_threshold) {
  * back-tracking to resize the previous line if it collides.
  * returns a status struct (used for error information)
  */
-status_t
-resize_spiral(
+status_t resize_spiral(
     spiral_t * spiral, size_t index, uint32_t length, int perfection_threshold
 ) {
     /*
@@ -241,8 +240,7 @@ resize_spiral(
  * store these in a the spiral struct that is pointed to by the pointer
  * returns a status struct (used for error information)
  */
-status_t
-plot_spiral(spiral_t * spiral, int perfection_threshold) {
+status_t plot_spiral(spiral_t * spiral, int perfection_threshold) {
     // set up result status
     status_t result = {{0, 0, 0}, 0};
     // calculate the length of each line

--- a/saxbospiral/solve.h
+++ b/saxbospiral/solve.h
@@ -18,8 +18,7 @@ extern "C"{
  * back-tracking to resize the previous line if it collides.
  * returns a status struct (used for error information)
  */
-status_t
-resize_spiral(
+status_t resize_spiral(
     spiral_t * spiral, size_t index, uint32_t length, int perfection_threshold
 );
 
@@ -31,8 +30,7 @@ resize_spiral(
  * store these in a the spiral struct that is pointed to by the pointer
  * returns a status struct (used for error information)
  */
-status_t
-plot_spiral(spiral_t * spiral, int perfection_threshold);
+status_t plot_spiral(spiral_t * spiral, int perfection_threshold);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/sxp.c
+++ b/sxp.c
@@ -18,8 +18,7 @@ extern "C"{
 #endif
 
 // returns size of file associated with given file handle
-size_t
-get_file_size(FILE * file_handle) {
+size_t get_file_size(FILE * file_handle) {
     // seek to end
     fseek(file_handle, 0L, SEEK_END);
     // get size
@@ -33,8 +32,7 @@ get_file_size(FILE * file_handle) {
  * given an open file handle and a buffer, read the file contents into buffer
  * returns true on success and false on failure.
  */
-bool
-file_to_buffer(FILE * file_handle, buffer_t * buffer) {
+bool file_to_buffer(FILE * file_handle, buffer_t * buffer) {
     size_t file_size = get_file_size(file_handle);
     // allocate/re-allocate buffer memory
     if(buffer->bytes == NULL) {
@@ -64,8 +62,7 @@ file_to_buffer(FILE * file_handle, buffer_t * buffer) {
  * to the file.
  * returns true on success and false on failure.
  */
-bool
-buffer_to_file(buffer_t * buffer, FILE * file_handle) {
+bool buffer_to_file(buffer_t * buffer, FILE * file_handle) {
     size_t bytes_written = fwrite(
         buffer->bytes, 1, buffer->size, file_handle
     );
@@ -81,8 +78,7 @@ buffer_to_file(buffer_t * buffer, FILE * file_handle) {
  * private function, given a diagnostic_t error, returns the string name of the
  * error code
  */
-static const char *
-error_code_string(diagnostic_t error) {
+static const char * error_code_string(diagnostic_t error) {
     switch(error) {
         case OPERATION_FAIL:
             return "OPERATION_FAIL";
@@ -102,8 +98,7 @@ error_code_string(diagnostic_t error) {
  * private function, given a deserialise_diagnostic_t error, returns the string
  * name of the error code
  */
-static const char *
-file_error_code_string(deserialise_diagnostic_t error) {
+static const char * file_error_code_string(deserialise_diagnostic_t error) {
     switch(error) {
         case DESERIALISE_OK:
             return "DESERIALISE_OK (NO ERROR)";
@@ -124,8 +119,7 @@ file_error_code_string(deserialise_diagnostic_t error) {
  * private function to handle all generic errors, by printing to stderr
  * returns true if there was an error, false if not
  */
-static bool
-handle_error(status_t result) {
+static bool handle_error(status_t result) {
     // if we had problems, print to stderr and return true
     if(result.diagnostic != OPERATION_OK) {
         fprintf(
@@ -145,8 +139,7 @@ handle_error(status_t result) {
  * options configured via command-line.
  * returns true on success, false on failure.
  */
-bool
-run(
+bool run(
     bool prepare, bool generate, bool render, bool perfect, int perfect_threshold,
     const char * input_file_path, const char * output_file_path
 ) {
@@ -255,8 +248,7 @@ run(
 }
 
 // main - mostly just process arguments, the bulk of the work is done by run()
-int
-main(int argc, char * argv[]) {
+int main(int argc, char * argv[]) {
     // status code initially set to -1
     int status_code = -1;
     // build argtable struct for parsing command-line arguments

--- a/sxp.h
+++ b/sxp.h
@@ -13,31 +13,27 @@ extern "C"{
 #endif
 
 // returns size of file associated with given file handle
-size_t
-get_file_size(FILE * file_handle);
+size_t get_file_size(FILE * file_handle);
 
 /*
  * given an open file handle and a buffer, read the file contents into buffer
  * returns true on success and false on failure.
  */
-bool
-file_to_buffer(FILE * file_handle, buffer_t * buffer);
+bool file_to_buffer(FILE * file_handle, buffer_t * buffer);
 
 /*
  * given a buffer struct and an open file handle, writes the buffer contents
  * to the file.
  * returns true on success and false on failure.
  */
-bool
-buffer_to_file(buffer_t * buffer, FILE * file_handle);
+bool buffer_to_file(buffer_t * buffer, FILE * file_handle);
 
 /*
  * function responsible for actually doing the main work, called by main with
  * options configured via command-line.
  * returns true on success, false on failure.
  */
-bool
-run(
+bool run(
     bool prepare, bool generate, bool render, bool perfect, int perfect_threshold,
     const char * input_file_path, const char * output_file_path
 );

--- a/tests.c
+++ b/tests.c
@@ -10,8 +10,7 @@
 #include "saxbospiral/serialise.h"
 
 
-bool
-test_change_direction() {
+bool test_change_direction() {
     if(change_direction(UP, CLOCKWISE) != RIGHT) {
         return false;
     } else if(change_direction(UP, ANTI_CLOCKWISE) != LEFT) {
@@ -29,8 +28,7 @@ test_change_direction() {
     }
 }
 
-bool
-test_init_spiral() {
+bool test_init_spiral() {
     // success / failure variable
     bool result = true;
     // build buffer of bytes for input data
@@ -75,8 +73,7 @@ test_init_spiral() {
     return result;
 }
 
-bool
-test_spiral_points() {
+bool test_spiral_points() {
     // success variable
     bool success = true;
     // prepare input spiral struct
@@ -130,8 +127,7 @@ test_spiral_points() {
     return success;
 }
 
-bool
-test_cache_spiral_points_blank() {
+bool test_cache_spiral_points_blank() {
     // success variable
     bool success = true;
     // prepare input spiral struct
@@ -185,8 +181,7 @@ test_cache_spiral_points_blank() {
     return success;
 }
 
-bool
-test_plot_spiral() {
+bool test_plot_spiral() {
     // success / failure variable
     bool result = true;
     // build input and output structs
@@ -226,8 +221,7 @@ test_plot_spiral() {
     return result;
 }
 
-bool
-test_load_spiral() {
+bool test_load_spiral() {
     // success / failure variable
     bool result = true;
     // build buffer of bytes for input data
@@ -302,8 +296,7 @@ test_load_spiral() {
     return result;
 }
 
-bool
-test_load_spiral_rejects_missing_magic_number() {
+bool test_load_spiral_rejects_missing_magic_number() {
     // success / failure variable
     bool result = true;
     // build buffer of bytes for input data
@@ -326,8 +319,7 @@ test_load_spiral_rejects_missing_magic_number() {
     return result;
 }
 
-bool
-test_load_spiral_rejects_too_small_for_header() {
+bool test_load_spiral_rejects_too_small_for_header() {
     // success / failure variable
     bool result = true;
     // build buffer of bytes for input data - should be smaller than 26
@@ -350,8 +342,7 @@ test_load_spiral_rejects_too_small_for_header() {
     return result;
 }
 
-bool
-test_load_spiral_rejects_too_small_data_section() {
+bool test_load_spiral_rejects_too_small_data_section() {
     // success / failure variable
     bool result = true;
     // build buffer of bytes for input data
@@ -388,8 +379,7 @@ test_load_spiral_rejects_too_small_data_section() {
     return result;
 }
 
-bool
-test_dump_spiral() {
+bool test_dump_spiral() {
     // success / failure variable
     bool result = true;
     // build input struct
@@ -466,8 +456,7 @@ test_dump_spiral() {
 // a function pointer to a test case function, and a string containing the
 // test case's name. it will run the test case function and return the success
 // or failure status, which should be stored in the test suite status bool.
-bool
-run_test_case(
+bool run_test_case(
     bool test_suite_state, bool (*test_case_func)(), char * test_case_name
 ) {
     printf("%s: ", test_case_name);
@@ -477,8 +466,7 @@ run_test_case(
     return test_suite_state && test_result;
 }
 
-int
-main() {
+int main() {
     // set up test suite status flag
     bool result = true;
     // call run_test_case() for each test case


### PR DESCRIPTION
I've realised that I really don't like the GNU coding standards and
what they have to say on this topic...
