### PR TITLE
v0.19.2 - Improve 64-bit detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,14 @@ set(
 set(SAXBOSPIRAL_ESCAPED_VERSION_STRING "\"${SAXBOSPIRAL_VERSION_STRING}\"")
 # end basic metadata
 
+# this is a 64-bit project, so check now to make sure we're 64-bit, issue warning if not
+if(CMAKE_SIZEOF_VOID_P LESS 8)
+    message(
+        WARNING
+        "It looks like this system's architecture is not at least 64-bit.\n"
+        "libsaxbospiral requires a system with an architecture of at least 64 bits!")
+endif()
+
 # pass in version of library as preprocessor definitions
 add_definitions(-DSAXBOSPIRAL_VERSION_MAJOR=${PROJECT_VERSION_MAJOR})
 add_definitions(-DSAXBOSPIRAL_VERSION_MINOR=${PROJECT_VERSION_MINOR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
-project(libsaxbospiral VERSION 0.19.1 LANGUAGES C)
+project(libsaxbospiral VERSION 0.19.2 LANGUAGES C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Although this project doesn't work in sprints, there is a [*sprint board*](https
 
 ## Please Note
 
+- This software only works on systems capable of running 64-bit code.
+
 - This is a library only. If you're looking for something that is immediately usable for the end-user, you probably want to look at [sxbp](https://github.com/saxbophone/sxbp) instead, which is a command-line program I wrote which uses libsaxbospiral to render input binary files to PNG images.
 
 - As libsaxbospiral is currently at major version 0, expect the library API to be unstable. I will endeavour as much as possible to make sure breaking changes increment the minor version number whilst in the version 0.x.x series and bugfixes increment the patch version number, but no heavy reliance should be placed on this.

--- a/saxbospiral/render.c
+++ b/saxbospiral/render.c
@@ -20,12 +20,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-// sanity check for support of 64-bit integers
-#if __SIZEOF_SIZE_T__ < 8
-#warning "Please compile this code for a target with 64-bit words or greater."
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/saxbospiral/render.h
+++ b/saxbospiral/render.h
@@ -23,11 +23,6 @@
 #ifndef SAXBOPHONE_SAXBOSPIRAL_RENDER_H
 #define SAXBOPHONE_SAXBOSPIRAL_RENDER_H
 
-// sanity check for support of 64-bit integers
-#if __SIZEOF_SIZE_T__ < 8
-#warning "Please compile this code for a target with 64-bit words or greater."
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/saxbospiral/saxbospiral.h
+++ b/saxbospiral/saxbospiral.h
@@ -24,11 +24,6 @@
 #ifndef SAXBOPHONE_SAXBOSPIRAL_SAXBOSPIRAL_H
 #define SAXBOPHONE_SAXBOSPIRAL_SAXBOSPIRAL_H
 
-// sanity check for support of 64-bit integers
-#if __SIZEOF_SIZE_T__ < 8
-#warning "Please compile this code for a target with 64-bit words or greater."
-#endif
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/saxbospiral/serialise.c
+++ b/saxbospiral/serialise.c
@@ -21,12 +21,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-// sanity check for support of 64-bit integers
-#if __SIZEOF_SIZE_T__ < 8
-#warning "Please compile this code for a target with 64-bit words or greater."
-#endif
-
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/saxbospiral/solve.c
+++ b/saxbospiral/solve.c
@@ -22,12 +22,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-// sanity check for support of 64-bit integers
-#if __SIZEOF_SIZE_T__ < 8
-#warning "Please compile this code for a target with 64-bit words or greater."
-#endif
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/tests.c
+++ b/tests.c
@@ -483,8 +483,8 @@ bool test_sxbp_load_spiral_rejects_too_small_data_section() {
     // success / failure variable
     bool result = true;
     // build buffer of bytes for input data
-    sxbp_buffer_t buffer = { .size = 41, };
-    buffer.bytes = calloc(1, buffer.size);
+    sxbp_buffer_t buffer = { .size = 0xffffffffffffffffu, }; // max 64-bit uint
+    buffer.bytes = calloc(1, 41); // set allocation size to actual data size
     // construct data header
     sprintf(
         (char*)buffer.bytes,


### PR DESCRIPTION
CMake now responsible for this, removed non-standard #warning directives
in source files for 64-bit detection. CMake issues a warning only as there
is no guarantee that every 64-bit system has a void-pointer size of at least 8 bytes
Also, amended incorrect data size test case to set size field to UINT_64_MAX, so
that way the build is broken if attempted on a 32-bit system that truncates the 64-bit uints.