### PR TITLE
v0.19.3 - C99 + C11 Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ compiler:
   - clang
   # commenting out gcc until installing GCC v5.x+ actually works on Travis CI
   # - gcc
+# different C Standard versions - test on C99 and C11
+env:
+  - LIBSAXBOSPIRAL_C_STANDARD=99
+  - LIBSAXBOSPIRAL_C_STANDARD=11
 # exclude gcc on osx as this always points to clang
 matrix:
   exclude:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
+project(libsaxbospiral VERSION 0.19.3 LANGUAGES C)
+
 # set default C standard to use (C99)
 set(SAXBOSPIRAL_C_STANDARD "99")
 # if env variable LIBSAXBOSPIRAL_C_STANDARD is set and valid, override version
@@ -33,10 +35,9 @@ if(DEFINED ENV{LIBSAXBOSPIRAL_C_STANDARD})
     endif()
 endif()
 message(STATUS "C Standard set to C${SAXBOSPIRAL_C_STANDARD}")
-
-project(libsaxbospiral VERSION 0.19.2 LANGUAGES C)
 set(CMAKE_C_STANDARD ${SAXBOSPIRAL_C_STANDARD})
 set(CMAKE_C_STANDARD_REQUIRED ON)
+
 set(
     SAXBOSPIRAL_VERSION_STRING
     "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,19 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
+# set default C standard to use (C99)
+set(SAXBOSPIRAL_C_STANDARD "99")
+# if env variable LIBSAXBOSPIRAL_C_STANDARD is set and valid, override version
+if(DEFINED ENV{LIBSAXBOSPIRAL_C_STANDARD})
+    # not a very robust regex but ok for most purposes
+    if("$ENV{LIBSAXBOSPIRAL_C_STANDARD}" MATCHES "(99|11)")
+        set(SAXBOSPIRAL_C_STANDARD "$ENV{LIBSAXBOSPIRAL_C_STANDARD}")
+    endif()
+endif()
+message(STATUS "C Standard set to C${SAXBOSPIRAL_C_STANDARD}")
+
 project(libsaxbospiral VERSION 0.19.2 LANGUAGES C)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD ${SAXBOSPIRAL_C_STANDARD})
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(
     SAXBOSPIRAL_VERSION_STRING
@@ -62,7 +73,7 @@ endfunction()
 
 # enable extra flags (warnings) if we're not in release mode
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
-    message("Warnings Enabled")
+    message(STATUS "Warnings Enabled")
     # enable all warnings about 'questionable constructs'
     enable_c_compiler_flag_if_supported("-Wall")
     # issue 'pedantic' warnings for strict ISO compliance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ In addition, please make sure:
 
 - You commit files with Unix Line-endings (`\n` `<LF>` `0x0a`)
 - Each text file committed has a trailing newline at the end
+- Your C code is compliant to the ISO C99 and C11 standards
 - C source code is indented with 4 spaces per indentation level (no tabs)
 - Public functions are prototyped in the correct C Header file, all private declarations are declared `static`
 - Every public function (and ideally private too) has an accompanying explanatory comment

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Libsaxbospiral can be built without installing for test purposes and for general
 
 You will need:
 
-- A compiler that can compile ISO C99 code
+- A compiler that can compile ISO C99 or C11 code
 - [Cmake](https://cmake.org/) - v3.0 or newer
 - [libpng](http://www.libpng.org/pub/png/libpng.html) - (this often comes preinstalled with many modern unix-like systems)
 
@@ -50,7 +50,7 @@ You will need:
 
 > These commands are for unix-like systems, without an IDE or other build system besides CMake. If building for a different system, or within an IDE or other environment, consult your IDE/System documentation on how to build CMake projects.
 
-> Additionally, it is of worth noting that this library has only been thoroughly tested and developed on **Ubuntu GNU/Linux** with **GCC v5.4.0** and **Clang 3.8.0**. Although every effort has been made to make it as cross-platform as possible (including quite strict **ISO C 99** compliance), **Your Mileage May Vary**. Bug Reports and Patches for problems running on other systems, particularly **Microsoft Windows** and **Mac OSX** are most welcome.
+> Additionally, it is of worth noting that this library has only been thoroughly tested and developed on **Ubuntu GNU/Linux** with **GCC v5.4.0** and **Clang 3.8.0**. Although every effort has been made to make it as cross-platform as possible (including quite strict **ISO C99** and **ISO C11** compliance), **Your Mileage May Vary**. Bug Reports and Patches for problems running on other systems, particularly **Microsoft Windows** and **Mac OSX** are most welcome.
 
 ### Recommended Library Build
 
@@ -59,6 +59,14 @@ Invoke CMake within the root of this repository, with these arguments to make CM
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .
 make
+```
+
+The above builds in C99 mode by default. The standard to use is controlled by the `LIBSAXBOSPIRAL_C_STANDARD` environment variable.
+
+You can build in C11 mode if you want with the following:
+
+```sh
+LIBSAXBOSPIRAL_C_STANDARD=11 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .
 ```
 
 > ### Note:


### PR DESCRIPTION
Now able to verify that this project builds successfully in C11 mode, via CI build.
Modified CMake build file to allow the desired version of the C standard to be explicitly set to C99 or C11 via an environment variable.