### PR TITLE
Re-organise and refactor the rendering units

### DIFF
--- a/saxbospiral/render.h
+++ b/saxbospiral/render.h
@@ -48,7 +48,28 @@ typedef struct sxbp_bitmap_t {
  * - That image->pixels is NULL
  * - That spiral.lines is not NULL
  */
-sxbp_status_t sxbp_render_spiral(sxbp_spiral_t spiral, sxbp_bitmap_t* image);
+sxbp_status_t sxbp_render_spiral_raw(
+    sxbp_spiral_t spiral, sxbp_bitmap_t* image
+);
+
+/*
+ * given a spiral struct, a pointer to a blank buffer and a pointer to a
+ * function with the appropriate signature, render the spiral as a bitmap and
+ * then call the pointed-to function to render the image to the buffer (in
+ * whatever format the function pointer is written for)
+ * returns a status struct with error information (if any)
+ *
+ * Asserts:
+ * - That spiral.lines is not NULL
+ * - That buffer->bytes is NULL
+ * - That the function pointer is not NULL
+ */
+sxbp_status_t sxbp_render_spiral_image(
+    sxbp_spiral_t spiral, sxbp_buffer_t* buffer,
+    sxbp_status_t(* image_writer_callback)(
+        sxbp_bitmap_t image, sxbp_buffer_t* buffer
+    )
+);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/saxbospiral/render_backends/backend_png.c
+++ b/saxbospiral/render_backends/backend_png.c
@@ -2,7 +2,8 @@
  * This source file forms part of libsaxbospiral, a library which generates
  * experimental 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides functionality to render a bitmap struct to PNG
+ * This compilation unit provides functionality to render a bitmap struct to a
+ * PNG image (stored in a buffer).
  *
  *
  *
@@ -28,7 +29,7 @@
 
 #include "../saxbospiral.h"
 #include "../render.h"
-#include "png_backend.h"
+#include "backend_png.h"
 
 
 #ifdef __cplusplus
@@ -89,7 +90,7 @@ static void cleanup_png_lib(
  * - That bitmap.pixels is not NULL
  * - That buffer->bytes is NULL
  */
-sxbp_status_t sxbp_write_png_image(
+sxbp_status_t sxbp_render_backend_png(
     sxbp_bitmap_t bitmap, sxbp_buffer_t* buffer
 ) {
     // preconditional assertsions

--- a/saxbospiral/render_backends/backend_png.h
+++ b/saxbospiral/render_backends/backend_png.h
@@ -2,7 +2,8 @@
  * This source file forms part of libsaxbospiral, a library which generates
  * experimental 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides functionality to render a bitmap struct to PNG
+ * This compilation unit provides functionality to render a bitmap struct to a
+ * PNG image (stored in a buffer).
  *
  *
  *
@@ -20,8 +21,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef SAXBOPHONE_SAXBOSPIRAL_PNG_BACKEND_H
-#define SAXBOPHONE_SAXBOSPIRAL_PNG_BACKEND_H
+#ifndef SAXBOPHONE_SAXBOSPIRAL_BACKEND_PNG_H
+#define SAXBOPHONE_SAXBOSPIRAL_BACKEND_PNG_H
 
 #include "../saxbospiral.h"
 #include "../render.h"
@@ -40,7 +41,9 @@ extern "C"{
  * - That bitmap.pixels is not NULL
  * - That buffer->bytes is NULL
  */
-sxbp_status_t sxbp_write_png_image(sxbp_bitmap_t bitmap, sxbp_buffer_t* buffer);
+sxbp_status_t sxbp_render_backend_png(
+    sxbp_bitmap_t bitmap, sxbp_buffer_t* buffer
+);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
- Rename png backend unit and functions
- Rename basic render function to 'raw'
- Add new 'callback' render function for rendering straight to image buffer
Fixes #113