### PR TITLE
Enable gcc-5 builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: c
+# Ubuntu 14.04 Trusty support
+sudo: required
+dist: trusty
 # build matrix with both OSes and Compilers
 os:
   - linux
   - osx
 compiler:
   - clang
-  # commenting out gcc until installing GCC v5.x+ actually works on Travis CI
-  # - gcc
+  - gcc
 # different C Standard versions - test on C99 and C11
 env:
   - LIBSAXBOSPIRAL_C_STANDARD=99
@@ -21,13 +23,14 @@ cache:
 addons:
   apt:
     sources:
+      # add PPAs with more up-to-date toolchains
+      - ubuntu-toolchain-r-test
       - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
     packages:
       - cmake
       - cmake-data
-      # commenting out gcc until installing GCC v5.x+ actually works on Travis CI
       # want gcc 5.x as 4.x gives incorrect warnings
-      # - gcc-5
+      - gcc-5
 # branches safelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ compiler:
   - gcc
 # different C Standard versions - test on C99 and C11
 env:
-  global:
-    # set gcc to version 5
-    - GCC_VERSION=5
   matrix:
     - LIBSAXBOSPIRAL_C_STANDARD=99
     - LIBSAXBOSPIRAL_C_STANDARD=11
@@ -41,6 +38,9 @@ branches:
     - master
     - develop
     - /^test\/.*$/
+install:
+  # override $CC to use gcc-5
+  - if [ "$CC" = "gcc" ]; then export CC="gcc-5"; fi
 before_script:
   - cmake .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ os:
 compiler:
   - clang
   - gcc
+    addons:
+      apt:
+        sources:
+          # add PPAs with more up-to-date toolchains
+          - ubuntu-toolchain-r-test
+        packages:
+          # want gcc 5.x as 4.x gives incorrect warnings
+          - gcc-5
+      env:
+        # override compiler to gcc 5.x
+        - COMPILER=gcc-5
 # different C Standard versions - test on C99 and C11
 env:
   - LIBSAXBOSPIRAL_C_STANDARD=99
@@ -23,14 +34,10 @@ cache:
 addons:
   apt:
     sources:
-      # add PPAs with more up-to-date toolchains
-      - ubuntu-toolchain-r-test
       - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
     packages:
       - cmake
       - cmake-data
-      # want gcc 5.x as 4.x gives incorrect warnings
-      - gcc-5
 # branches safelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,13 @@ compiler:
   - gcc
 # different C Standard versions - test on C99 and C11
 env:
-  - LIBSAXBOSPIRAL_C_STANDARD=99
-  - LIBSAXBOSPIRAL_C_STANDARD=11
+  global:
+    # set gcc to version 5
+    - GCC_VERSION=5
+  matrix:
+    - LIBSAXBOSPIRAL_C_STANDARD=99
+    - LIBSAXBOSPIRAL_C_STANDARD=11
 matrix:
-  include:
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            # add PPAs with more up-to-date toolchains
-            - ubuntu-toolchain-r-test
-          packages:
-            # want gcc 5.x as 4.x gives incorrect warnings
-            - gcc-5
-      env:
-        # override compiler to gcc 5.x
-        - COMPILER=gcc-5
   # exclude gcc on osx as this always points to clang
   exclude:
   - os: osx
@@ -37,9 +28,13 @@ addons:
   apt:
     sources:
       - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
+      # add PPAs with more up-to-date toolchains
+      - ubuntu-toolchain-r-test
     packages:
       - cmake
       - cmake-data
+      # want gcc 5.x as 4.x gives incorrect warnings
+      - gcc-5
 # branches safelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,25 @@ os:
 compiler:
   - clang
   - gcc
-    addons:
-      apt:
-        sources:
-          # add PPAs with more up-to-date toolchains
-          - ubuntu-toolchain-r-test
-        packages:
-          # want gcc 5.x as 4.x gives incorrect warnings
-          - gcc-5
-      env:
-        # override compiler to gcc 5.x
-        - COMPILER=gcc-5
 # different C Standard versions - test on C99 and C11
 env:
   - LIBSAXBOSPIRAL_C_STANDARD=99
   - LIBSAXBOSPIRAL_C_STANDARD=11
-# exclude gcc on osx as this always points to clang
 matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            # add PPAs with more up-to-date toolchains
+            - ubuntu-toolchain-r-test
+          packages:
+            # want gcc 5.x as 4.x gives incorrect warnings
+            - gcc-5
+      env:
+        # override compiler to gcc 5.x
+        - COMPILER=gcc-5
+  # exclude gcc on osx as this always points to clang
   exclude:
   - os: osx
     compiler: gcc


### PR DESCRIPTION
A number of sources helped me achieve this, mainly:
- http://genbattle.bitbucket.org/blog/2016/01/17/c++-travis-ci/
- http://cdunn2001.blogspot.co.uk/2015/06/using-c11-in-travis-ci.html

Replaces #133