### PR TITLE
An experiment to check if small types affect perf.

### DIFF
--- a/saxbospiral/initialise.c
+++ b/saxbospiral/initialise.c
@@ -87,11 +87,11 @@ sxbp_status_t sxbp_init_spiral(sxbp_buffer_t buffer, sxbp_spiral_t* spiral) {
      */
     for(size_t s = 0; s < buffer.size; s++) {
         // byte-level loop
-        for(uint8_t b = 0; b < 8; b++) {
+        for(size_t b = 0; b < 8; b++) {
             // bit level loop
-            uint8_t e = 7 - b; // which power of two to use with bit mask
-            uint8_t bit = (buffer.bytes[s] & (1 << e)) >> e; // the current bit
-            size_t index = (s * 8) + (size_t)b + 1; // line index
+            size_t e = 7 - b; // which power of two to use with bit mask
+            size_t bit = (buffer.bytes[s] & (1 << e)) >> e; // the current bit
+            size_t index = (s * 8) + b + 1; // line index
             sxbp_rotation_t rotation; // the rotation we're going to make
             // set rotation direction based on the current bit
             rotation = (bit == 0) ? SXBP_CLOCKWISE : SXBP_ANTI_CLOCKWISE;

--- a/saxbospiral/render_backends/backend_pbm.c
+++ b/saxbospiral/render_backends/backend_pbm.c
@@ -114,7 +114,7 @@ sxbp_status_t sxbp_render_backend_pbm(
                 // byte index is index + floor(x / 8)
                 size_t byte_index = index + (x / 8);
                 // bit index is x mod 8
-                uint8_t bit_index = x % 8;
+                size_t bit_index = x % 8;
                 // write bits most-significant-bit first
                 buffer->bytes[byte_index] |= (
                     // black pixel = bool true = 1, just like in PBM format

--- a/saxbospiral/serialise.c
+++ b/saxbospiral/serialise.c
@@ -49,7 +49,7 @@ static uint64_t load_uint64_t(sxbp_buffer_t* buffer, size_t start_index) {
     // preconditional assertions
     assert(buffer->bytes != NULL);
     uint64_t value = 0;
-    for(uint8_t i = 0; i < 8; i++) {
+    for(size_t i = 0; i < 8; i++) {
         value |= (buffer->bytes[start_index + i]) << (8 * (7 - i));
     }
     return value;
@@ -65,7 +65,7 @@ static uint32_t load_uint32_t(sxbp_buffer_t* buffer, size_t start_index) {
     // preconditional assertions
     assert(buffer->bytes != NULL);
     uint32_t value = 0;
-    for(uint8_t i = 0; i < 4; i++) {
+    for(size_t i = 0; i < 4; i++) {
         value |= (buffer->bytes[start_index + i]) << (8 * (3 - i));
     }
     return value;
@@ -82,8 +82,8 @@ static void dump_uint64_t(
 ) {
     // preconditional assertions
     assert(buffer->bytes != NULL);
-    for(uint8_t i = 0; i < 8; i++) {
-        uint8_t shift = (8 * (7 - i));
+    for(size_t i = 0; i < 8; i++) {
+        size_t shift = (8 * (7 - i));
         buffer->bytes[start_index + i] = (uint8_t)(
             (value & (0xffUL << shift)) >> shift
         );
@@ -101,8 +101,8 @@ static void dump_uint32_t(
 ) {
     // preconditional assertions
     assert(buffer->bytes != NULL);
-    for(uint8_t i = 0; i < 4; i++) {
-        uint8_t shift = (8 * (3 - i));
+    for(size_t i = 0; i < 4; i++) {
+        size_t shift = (8 * (3 - i));
         buffer->bytes[start_index + i] = (uint8_t)(
             (value & (0xffUL << shift)) >> shift
         );
@@ -191,7 +191,7 @@ sxbp_serialise_result_t sxbp_load_spiral(
             & 0x3f // <= binary value is 0b00111111
         ) << 24;
         // handle remaining 3 bytes in loop
-        for(uint8_t j = 0; j < 3; j++) {
+        for(size_t j = 0; j < 3; j++) {
             spiral->lines[i].length |= (
                 buffer.bytes[SXBP_FILE_HEADER_SIZE + (i * SXBP_LINE_T_PACK_SIZE) + 1 + j]
             ) << (8 * (2 - j));
@@ -254,7 +254,7 @@ sxbp_serialise_result_t sxbp_dump_spiral(
             SXBP_FILE_HEADER_SIZE + (i * SXBP_LINE_T_PACK_SIZE)
         ] |= (spiral.lines[i].length >> 24);
         // handle remaining 3 bytes in a loop
-        for(uint8_t j = 0; j < 3; j++) {
+        for(size_t j = 0; j < 3; j++) {
             buffer->bytes[
                 SXBP_FILE_HEADER_SIZE + (i * SXBP_LINE_T_PACK_SIZE) + 1 + j
             ] = (uint8_t)(spiral.lines[i].length >> (8 * (2 - j)));


### PR DESCRIPTION
I ran the test suite 1000 times and timed it (twice).
I then amended the data type of all loop indexes to use size_t (they were using the smallest possible size for the loop range before).
I then ran the test suite 1000 times and timed it again (twice).

These are the results (all code compiled with GCC 5.4, with full optimisation)

Test code
================

(running the unit tests 1000 times):

```sh
time for i in $(seq 1 1000); do
    make test >/dev/null 2>&1;
done
```

----------------

Results
================

Using smallest possible sizes (2 tries):

```
real    0m15.272s
user    0m6.904s
sys 0m1.344s

real    0m15.328s
user    0m7.152s
sys 0m1.104s
```

----------------

Using size_t's (2 tries)

```
real    0m15.267s
user    0m7.048s
sys 0m1.220s

real    0m15.381s
user    0m7.052s
sys 0m1.252s
```

Signed-off-by: Joshua Saxby <joshua.a.saxby+UMvLnvbsOxBHaeiCHvbdunpz@gmail.com>