### PR TITLE
Add functions for making blank instances of public data types

### DIFF
--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -47,7 +47,7 @@ static bool sxbp_figure_collides(const sxbp_figure_t* figure) {
     // get spiral bounds first
     sxbp_bounds_t bounds = sxbp_get_bounds(figure);
     // build bitmap for bounds
-    sxbp_bitmap_t bitmap =  { 0 };
+    sxbp_bitmap_t bitmap =  sxbp_blank_bitmap();
     if (!sxbp_make_bitmap_for_bounds(bounds, &bitmap)) {
         // TODO: implment better error-handling than this
         abort();

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -138,6 +138,14 @@ typedef struct sxbp_bitmap_t {
 extern const sxbp_version_t SXBP_VERSION;
 
 /**
+ * @brief Creates a blank empty buffer
+ * @details Ensures that all pointer fields are properly initialised to NULL
+ * @returns An `sxbp_buffer_t` object with all fields set to default/blank value
+ * @since v0.54.0
+ */
+sxbp_buffer_t sxbp_blank_buffer(void);
+
+/**
  * @brief Attempts to allocate memory for the bytes of the given buffer
  * @details Attempts to allocate the amount of memory specified by the `size`
  * member of the buffer
@@ -176,6 +184,14 @@ bool sxbp_free_buffer(sxbp_buffer_t* buffer);
  * @since v0.54.0
  */
 bool sxbp_copy_buffer(const sxbp_buffer_t* from, sxbp_buffer_t* to);
+
+/**
+ * @brief Creates a blank empty figure
+ * @details Ensures that all pointer fields are properly initialised to NULL
+ * @returns An `sxbp_figure_t` object with all fields set to default/blank value
+ * @since v0.54.0
+ */
+sxbp_figure_t sxbp_blank_figure(void);
 
 /**
  * @brief Attempts to allocate memory for dynamic members of the given figure
@@ -218,6 +234,14 @@ bool sxbp_free_figure(sxbp_figure_t* figure);
  * @since v0.54.0
  */
 bool sxbp_copy_figure(const sxbp_figure_t* from, sxbp_figure_t* to);
+
+/**
+ * @brief Creates a blank empty bitmap
+ * @details Ensures that all pointer fields are properly initialised to NULL
+ * @returns An `sxbp_bitmap_t` object with all fields set to default/blank value
+ * @since v0.54.0
+ */
+sxbp_bitmap_t sxbp_blank_bitmap(void);
 
 /**
  * @brief Attempts to allocate memory for the pixels of the given bitmap

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -23,6 +23,10 @@
 extern "C"{
 #endif
 
+sxbp_buffer_t sxbp_blank_buffer(void) {
+    return (sxbp_buffer_t){ .size = 0, .bytes = NULL, };
+}
+
 bool sxbp_init_buffer(sxbp_buffer_t* buffer) {
     // allocate memory with calloc to make sure all bytes are set to zero
     buffer->bytes = calloc(buffer->size, sizeof(uint8_t));
@@ -57,6 +61,10 @@ bool sxbp_copy_buffer(const sxbp_buffer_t* from, sxbp_buffer_t* to) {
         memcpy(to->bytes, from->bytes, to->size);
         return true;
     }
+}
+
+sxbp_figure_t sxbp_blank_figure(void) {
+    return (sxbp_figure_t){ .size = 0, .lines = NULL, .lines_remaining = 0, };
 }
 
 bool sxbp_init_figure(sxbp_figure_t* figure) {
@@ -94,6 +102,10 @@ bool sxbp_copy_figure(const sxbp_figure_t* from, sxbp_figure_t* to) {
         memcpy(to->lines, from->lines, to->size);
         return true;
     }
+}
+
+sxbp_bitmap_t sxbp_blank_bitmap(void) {
+    return (sxbp_bitmap_t){ .width = 0, .height = 0, .pixels = NULL, };
 }
 
 // allocates memory for one column of a bitmap, returning whether it succeeded

--- a/tests.c
+++ b/tests.c
@@ -28,7 +28,7 @@ int main(void) {
         return -1;
     } else {
         memcpy(buffer.bytes, string, length);
-        sxbp_figure_t figure = { 0 };
+        sxbp_figure_t figure = sxbp_blank_figure();
         sxbp_begin_figure(&buffer, &figure);
         sxbp_refine_figure(&figure);
         sxbp_free_figure(&figure);


### PR DESCRIPTION
These are handy for the user not having to worry about uninitialised fields (although they could just use `{ 0 }` which initialises all fields to zero in C).
The benefits that providing functions for these has over just using the built-in syntax is:
- user doesn't have to worry about it
- in the unlikely scenario that NULL != 0, they're still covered :thinking: 