### PR TITLE
Enable strict enforcing of empty function declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_c_compiler_flag_if_supported("-pedantic")
     # enable 'extra' strict warnings
     enable_c_compiler_flag_if_supported("-Wextra")
+    # enable enforcing of strict function prototypes (e.g. no empty parentheses)
+    enable_c_compiler_flag_if_supported("-Wstrict-prototypes")
     # enable warnings on missing prototypes of global functions
     enable_c_compiler_flag_if_supported("-Wmissing-prototypes")
     # convert all warnings into errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,12 @@ function(enable_c_compiler_flag_if_supported flag)
     if(flag_already_set EQUAL -1)
         check_c_compiler_flag("${flag}" flag_supported)
         if(flag_supported)
+            message(STATUS "[sxbp] Enabling warning flag ${flag}")
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}" PARENT_SCOPE)
         endif()
     endif()
+    unset(flag_already_set CACHE)
+    unset(flag_supported CACHE)
 endfunction()
 
 # enable extra flags (warnings) if we're not in release mode
@@ -82,10 +85,12 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_c_compiler_flag_if_supported("-Wstrict-prototypes")
     # enable warnings on missing prototypes of global functions
     enable_c_compiler_flag_if_supported("-Wmissing-prototypes")
-    # convert all warnings into errors
-    enable_c_compiler_flag_if_supported("-Werror")
     # turn off spurious warnings from clang about missing field initialisers
     enable_c_compiler_flag_if_supported("-Wno-missing-field-initializers")
+    # enable warnings about mistakes in Doxygen documentation
+    enable_c_compiler_flag_if_supported("-Wdocumentation")
+    # convert all warnings into errors
+    enable_c_compiler_flag_if_supported("-Werror")
 endif()
 
 # begin dependencies
@@ -129,7 +134,7 @@ endif()
 # C source files
 file(GLOB SXBP_SOURCES "sxbp/*.c")
 # Header files
-file(GLOB SXBP_HEADERS "sxbp/*.h")
+set(SXBP_HEADERS "sxbp/sxbp.h")
 
 add_library(sxbp ${SXBP_SOURCES})
 # set up version for library objects
@@ -171,20 +176,10 @@ install(
     FILES ${SXBP_HEADERS}
     DESTINATION "include/${SXBP_ROUGH_HEADER_DESTINATION}"
 )
-# Install render_backends header files
-install(
-    FILES ${SXBP_RENDER_BACKENDS_HEADERS}
-    DESTINATION "include/${SXBP_ROUGH_HEADER_DESTINATION}/render_backends"
-)
 
 install(
     FILES ${SXBP_HEADERS}
     DESTINATION "include/${SXBP_PRECISE_HEADER_DESTINATION}"
-)
-# Install render_backends header files
-install(
-    FILES ${SXBP_RENDER_BACKENDS_HEADERS}
-    DESTINATION "include/${SXBP_PRECISE_HEADER_DESTINATION}/render_backends"
 )
 
 enable_testing()

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -176,7 +176,7 @@ bool sxbp_free_buffer(sxbp_buffer_t* buffer);
  * separate at the completion of the operation. Any data in the `to` buffer
  * will be overwritten or erased.
  * @param from The buffer to copy the contents of
- * @param[out] The buffer to copy the contents to
+ * @param[out] to The buffer to copy the contents to
  * @warning The buffer to copy the contents to must be in a consistent state,
  * that is it must either not be allocated yet, or must be properly allocated.
  * @returns `true` if the data was copied successfully
@@ -250,7 +250,7 @@ bool sxbp_free_figure(sxbp_figure_t* figure);
  * separate at the completion of the operation. Any data in the `to` figure
  * will be overwritten or erased.
  * @param from The figure to copy the contents of
- * @param[out] The figure to copy the contents to
+ * @param[out] to The figure to copy the contents to
  * @warning The figure to copy the contents to must be in a consistent state,
  * that is it must either not be allocated yet, or must be properly allocated.
  * @returns `true` if the data was copied successfully
@@ -298,7 +298,7 @@ bool sxbp_free_bitmap(sxbp_bitmap_t* bitmap);
  * separate at the completion of the operation. Any data in the `to` bitmap
  * will be overwritten or erased.
  * @param from The bitmap to copy the contents of
- * @param[out] The bitmap to copy the contents to
+ * @param[out] to The bitmap to copy the contents to
  * @warning The bitmap to copy the contents to must be in a consistent state,
  * that is it must either not be allocated yet, or must be properly allocated.
  * @returns `true` if the data was copied successfully


### PR DESCRIPTION
In the most modern versions of C, function declarations with empty parentheses are invalid