### PR TITLE
Add new type `sxbp_figure_size_t` for size and indexing of figures

### DIFF
--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -109,7 +109,8 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
             // bit level loop - extract the bit
             uint8_t e = 7 - b; // which power of two to use with bit mask
             bool bit = (data->bytes[s] & (1 << e)) >> e; // the current bit
-            sxbp_figure_size_t index = (s * 8) + (uint32_t)b + 1; // line index
+            // this is the line index, derived from the bit of data we're on
+            sxbp_figure_size_t index = (s * 8) + (sxbp_figure_size_t)b + 1;
             // set rotation direction based on the current bit
             sxbp_rotation_t rotation = sxbp_rotation_from_bit(bit);
             // calculate the new direction

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -103,13 +103,13 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
      * make the spiral pattern, also deducing the length to set these to to
      * avoid any collisions
      */
-    for (uint32_t s = 0; s < data->size; s++) {
+    for (sxbp_figure_size_t s = 0; s < data->size; s++) {
         // byte-level loop
         for (uint8_t b = 0; b < 8; b++) {
             // bit level loop - extract the bit
             uint8_t e = 7 - b; // which power of two to use with bit mask
             bool bit = (data->bytes[s] & (1 << e)) >> e; // the current bit
-            uint32_t index = (s * 8) + (uint32_t)b + 1; // line index
+            sxbp_figure_size_t index = (s * 8) + (uint32_t)b + 1; // line index
             // set rotation direction based on the current bit
             sxbp_rotation_t rotation = sxbp_rotation_from_bit(bit);
             // calculate the new direction

--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -79,8 +79,8 @@ static bool sxbp_figure_collides(const sxbp_figure_t* figure) {
  */
 static void sxbp_attempt_line_shorten(
     sxbp_figure_t* figure,
-    const uint32_t l,
-    const uint32_t max
+    const sxbp_figure_size_t l,
+    const sxbp_figure_size_t max
 ) {
     sxbp_line_t* line = &figure->lines[l];
     // it only makes sense to try and shorten lines longer than 1
@@ -104,7 +104,7 @@ static void sxbp_attempt_line_shorten(
          */
         if (line->length < original_length) {
             // try and shorten other lines some more
-            for (uint32_t i = max; i >= l; i--) {
+            for (sxbp_figure_size_t i = max; i >= l; i--) {
                 sxbp_attempt_line_shorten(figure, i, max);
             }
         }
@@ -118,7 +118,7 @@ bool sxbp_refine_figure(sxbp_figure_t* figure) {
         return false;
     } else {
         // iterate over lines backwards - we don't care about line 0
-        for (uint32_t i = figure->size - 1; i > 0; i--) {
+        for (sxbp_figure_size_t i = figure->size - 1; i > 0; i--) {
             // try and shorten it
             sxbp_attempt_line_shorten(figure, i, figure->size - 1);
         }

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -149,7 +149,7 @@ static void sxbp_write_sxbp_data_body(
     sxbp_buffer_t* buffer,
     size_t* index
 ) {
-    for (uint32_t i = 0; i < figure->size; i++) {
+    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
         sxbp_write_sxbp_data_line(figure->lines[i], buffer, index);
     }
 }
@@ -272,7 +272,7 @@ static void sxbp_read_sxbp_data_body(
     sxbp_figure_t* figure,
     size_t* index
 ) {
-    for (uint32_t i = 0; i < figure->size; i++) {
+    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
         sxbp_read_sxbp_data_line(buffer, &figure->lines[i], index);
     }
 }

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -80,6 +80,14 @@ typedef enum sxbp_direction_t {
 typedef uint32_t sxbp_length_t;
 
 /**
+ * @brief Type for representing the size of an SXBP figure
+ * @details In other words, this is the type for storing the count of lines in
+ * the figure.
+ * @since v0.54.0
+ */
+typedef uint32_t sxbp_figure_size_t;
+
+/**
  * @brief Represents one line segment in the spiral structure.
  * @details This includes the direction of the line and it's length
  * (initially set to 0).
@@ -100,7 +108,7 @@ typedef struct sxbp_line_t {
  */
 typedef struct sxbp_figure_t {
     /** @brief The total number of lines in the figure */
-    uint32_t size;
+    sxbp_figure_size_t size;
     /** @brief The lines that make up the figure */
     sxbp_line_t* lines;
     /**
@@ -110,7 +118,7 @@ typedef struct sxbp_figure_t {
      * @note While this is greater than zero, it is the index of the next line
      * that needs solving + 1
      */
-    uint32_t lines_remaining;
+    sxbp_figure_size_t lines_remaining;
 } sxbp_figure_t;
 
 /**

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -72,7 +72,7 @@ sxbp_bounds_t sxbp_get_bounds(const sxbp_figure_t* figure, size_t scale) {
     sxbp_co_ord_t location = { 0 }; // where the end of the last line is
     sxbp_bounds_t bounds = { 0 }; // the bounds of the line walked so far
     // walk the line!
-    for (uint32_t i = 0; i < figure->size; i++) {
+    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
         // update the location, scaling in proportion to scale
         sxbp_move_location(
             &location,
@@ -116,10 +116,10 @@ void sxbp_walk_figure(
         return;
     }
     // for each line, plot separate points along their length
-    for (uint32_t i = 0; i < figure->size; i++) {
+    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
         sxbp_line_t line = figure->lines[i];
         // scale the line's size
-        for (uint32_t l = 0; l < line.length * scale; l++) {
+        for (sxbp_figure_size_t l = 0; l < line.length * scale; l++) {
             // move the location
             sxbp_move_location(&location, line.direction, 1);
             // plot a point, if callback returned false then exit
@@ -148,8 +148,8 @@ bool sxbp_make_bitmap_for_bounds(
 }
 
 void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream) {
-    for (uint32_t y = 0; y < bitmap->height; y++) {
-        for (uint32_t x = 0; x < bitmap->width; x++) {
+    for (sxbp_figure_size_t y = 0; y < bitmap->height; y++) {
+        for (sxbp_figure_size_t x = 0; x < bitmap->width; x++) {
             fprintf(stream, bitmap->pixels[x][bitmap->height - 1 - y] ? "█" : "░");
         }
         fprintf(stream, "\n");


### PR DESCRIPTION
This is more appropriate than using `uint32_t` as meaning is clearer and makes code easier to change in the future.