### PR TITLE
Add begin figure options

### DIFF
--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -153,11 +153,15 @@ sxbp_result_t sxbp_begin_figure(
          */
         figure->size = data->size * 8 + 1;
         /*
-         * if options->max_lines is not 0 and is less than the figure's size,
-         * then this means we need to make the figure size the size specified
-         * by max_lines
+         * if options is not NULL, options->max_lines is not 0 and is less than
+         * the figure's size, then this means we need to make the figure size
+         * the size specified by `max_lines`
          */
-        if (options->max_lines != 0 && options->max_lines < figure->size) {
+        if (
+            options != NULL &&
+            options->max_lines != 0 &&
+            options->max_lines < figure->size
+        ) {
             figure->size = options->max_lines;
         }
         // allocate memory for the figure

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -119,6 +119,10 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
             bool bit = (data->bytes[s] & (1 << e)) >> e; // the current bit
             // this is the line index, derived from the bit of data we're on
             sxbp_figure_size_t index = (s * 8) + (sxbp_figure_size_t)b + 1;
+            // do bounds-checking on the index, return early if out of bounds
+            if (index >= figure->size) {
+                return;
+            }
             // set rotation direction based on the current bit
             sxbp_rotation_t rotation = sxbp_rotation_from_bit(bit);
             // calculate the new direction
@@ -152,16 +156,16 @@ sxbp_result_t sxbp_begin_figure(
          * (byte count * 8) + 1 (for the extra starting line)
          */
         figure->size = data->size * 8 + 1;
+        // use default options if `options` is `NULL`
+        if (options == NULL) {
+            options = &SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;
+        }
         /*
-         * if options is not NULL, options->max_lines is not 0 and is less than
-         * the figure's size, then this means we need to make the figure size
-         * the size specified by `max_lines`
+         * if options->max_lines is not 0 and is less than the figure's size,
+         * then this means we need to make the figure size the size specified by
+         * `max_lines`
          */
-        if (
-            options != NULL &&
-            options->max_lines != 0 &&
-            options->max_lines < figure->size
-        ) {
+        if (options->max_lines != 0 && options->max_lines < figure->size) {
             figure->size = options->max_lines;
         }
         // allocate memory for the figure

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -138,6 +138,7 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
 
 sxbp_result_t sxbp_begin_figure(
     const sxbp_buffer_t* data,
+    const sxbp_begin_figure_options_t* options,
     sxbp_figure_t* figure
 ) {
     // check the buffer is not too large before doing anything else
@@ -151,6 +152,14 @@ sxbp_result_t sxbp_begin_figure(
          * (byte count * 8) + 1 (for the extra starting line)
          */
         figure->size = data->size * 8 + 1;
+        /*
+         * if options->max_lines is not 0 and is less than the figure's size,
+         * then this means we need to make the figure size the size specified
+         * by max_lines
+         */
+        if (options->max_lines != 0 && options->max_lines < figure->size) {
+            figure->size = options->max_lines;
+        }
         // allocate memory for the figure
         if (!sxbp_success(sxbp_init_figure(figure))) {
             // exit early and signal error status - can only be a memory error

--- a/sxbp/sxbp.c
+++ b/sxbp/sxbp.c
@@ -29,6 +29,10 @@ const sxbp_version_t SXBP_VERSION = {
 
 const size_t SXBP_BEGIN_BUFFER_MAX_SIZE = 1073741823;
 
+const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT = {
+    .max_lines = 0,
+};
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -122,6 +122,21 @@ typedef struct sxbp_figure_t {
 } sxbp_figure_t;
 
 /**
+ * @brief A structure used for providing options to `sxbp_begin_figure()`
+ * @since v0.54.0
+ */
+typedef struct sxbp_begin_figure_options_t {
+    /**
+     * @brief The maximum number of lines to create in the figure
+     * @details If 0, then the maximum number of lines possible (based on the
+     * input data size) is used.
+     * @note If this is greater than the maximum number of lines possible, then
+     * the latter is used.
+     */
+    sxbp_figure_size_t max_lines;
+} sxbp_begin_figure_options_t;
+
+/**
  * @brief Used to represent a basic 1-bit, pure black/white bitmap image.
  * @details The image has integer height and width, and a 2-dimensional array of
  * 1-bit pixels which are either black or white.
@@ -379,6 +394,9 @@ sxbp_result_t sxbp_copy_bitmap(const sxbp_bitmap_t* from, sxbp_bitmap_t* to);
  * directions and from these an unrefined rudimentary line is plotted in the
  * figure (by setting the directions and lengths of the figure's lines).
  * @param data The buffer containing data to generate the figure from
+ * @param options An optional options struct to specify additional options for
+ * starting the figure. This can be `NULL`, in which case the default options
+ * are used.
  * @param[out] figure The figure in which to generate the line. This will be
  * erased before data is written to it.
  * @note The shape that can be derived from this data will waste a lot of visual
@@ -395,6 +413,7 @@ sxbp_result_t sxbp_copy_bitmap(const sxbp_bitmap_t* from, sxbp_bitmap_t* to);
  */
 sxbp_result_t sxbp_begin_figure(
     const sxbp_buffer_t* data,
+    const sxbp_begin_figure_options_t* options,
     sxbp_figure_t* figure
 );
 

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -128,7 +128,7 @@ typedef struct sxbp_figure_t {
 typedef struct sxbp_begin_figure_options_t {
     /**
      * @brief The maximum number of lines to create in the figure
-     * @details If 0, then the maximum number of lines possible (based on the
+     * @details If `0`, then the maximum number of lines possible (based on the
      * input data size) is used.
      * @note If this is greater than the maximum number of lines possible, then
      * the latter is used.
@@ -191,6 +191,11 @@ extern const sxbp_version_t SXBP_VERSION;
  * size or larger can be used to create a figure, but less than 1GiB is fine.
  */
 extern const size_t SXBP_BEGIN_BUFFER_MAX_SIZE;
+
+/**
+ * @brief The default options used for `sxbp_begin_figure()`
+ */
+extern const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;
 
 /**
  * @brief Returns if a given `sxbp_result_t` is successful or not
@@ -404,7 +409,6 @@ sxbp_result_t sxbp_copy_bitmap(const sxbp_bitmap_t* from, sxbp_bitmap_t* to);
  * @warning Figures cannot be created from buffers larger than
  * `SXBP_BEGIN_BUFFER_MAX_SIZE` -- an error will be returned if this is
  * attempted.
- * @todo Add options struct (at least one option, max number of lines)
  * @returns `SXBP_RESULT_OK` if the figure could be successfully generated
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the figure could not be successfully
  * generated

--- a/tests.c
+++ b/tests.c
@@ -30,7 +30,7 @@ int main(void) {
     } else {
         memcpy(buffer.bytes, string, length);
         sxbp_figure_t figure = sxbp_blank_figure();
-        sxbp_begin_figure(&buffer, &figure);
+        sxbp_begin_figure(&buffer, NULL, &figure);
         sxbp_free_buffer(&buffer);
         // render incomplete figure to bitmap
         sxbp_bitmap_t bitmap = sxbp_blank_bitmap();


### PR DESCRIPTION
Add an optional options struct parameter to `sxbp_begin_figure()`, with currently one member, `max_lines`.
If this is non-zero, `sxbp_begin_figure()` will not plot more lines than this number.

Closes #189