### PR TITLE
Check null pointer errors

### DIFF
--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -145,6 +145,9 @@ sxbp_result_t sxbp_begin_figure(
     const sxbp_begin_figure_options_t* options,
     sxbp_figure_t* figure
 ) {
+    // data and figure must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(data);
+    SXBP_RETURN_FAIL_IF_NULL(figure);
     // check the buffer is not too large before doing anything else
     if (data->size > SXBP_BEGIN_BUFFER_MAX_SIZE) {
         return SXBP_RESULT_FAIL_PRECONDITION;

--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -145,6 +145,8 @@ sxbp_result_t sxbp_refine_figure(
     sxbp_figure_t* figure,
     const sxbp_refine_figure_options_t* options
 ) {
+    // figure must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(figure);
     // we can't refine a figure that has no lines allocated, so check this first
     if (figure->lines == NULL) {
         // bail early, we can't do anything with this

--- a/sxbp/render_figure.c
+++ b/sxbp/render_figure.c
@@ -57,6 +57,9 @@ sxbp_result_t sxbp_render_figure(
     const sxbp_figure_t* figure,
     sxbp_bitmap_t* bitmap
 ) {
+    // figure and bitmap must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(figure);
+    SXBP_RETURN_FAIL_IF_NULL(bitmap);
     // erase the bitmap structure first just in case
     sxbp_free_bitmap(bitmap);
     // get figure bounds, at scale 2

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "sxbp.h"
+#include "sxbp_internal.h"
 
 
 #ifdef __cplusplus
@@ -281,6 +282,9 @@ sxbp_result_t sxbp_dump_figure(
     const sxbp_figure_t* figure,
     sxbp_buffer_t* buffer
 ) {
+    // figure and buffer must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(figure);
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
     // erase the buffer first of all just in case
     sxbp_free_buffer(buffer);
     // set buffer size to that needed for figure
@@ -305,6 +309,9 @@ sxbp_result_t sxbp_load_figure(
     const sxbp_buffer_t* buffer,
     sxbp_figure_t* figure
 ) {
+    // buffer and figure must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
+    SXBP_RETURN_FAIL_IF_NULL(figure);
     // erase the figure first of all just in case
     sxbp_free_figure(figure);
     // check that the buffer contains valid sxbp data

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -257,6 +257,7 @@ sxbp_buffer_t sxbp_blank_buffer(void);
  * been allocated
  * @returns `SXBP_RESULT_OK` if memory was allocated successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if memory was not allocated successfully
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `buffer` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer);
@@ -285,6 +286,7 @@ bool sxbp_free_buffer(sxbp_buffer_t* const buffer);
  * @returns `SXBP_RESULT_OK` if the data was copied successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the data was not copied successfully,
  * in which case `to` will be empty.
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `from` or `to` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_copy_buffer(
@@ -300,6 +302,8 @@ sxbp_result_t sxbp_copy_buffer(
  * @param[out] buffer The buffer to write data to
  * @returns `SXBP_RESULT_OK` on successfully copying the file contents
  * @returns `SXBP_RESULT_FAIL_MEMORY` or `SXBP_RESULT_FAIL_FILE` on failure to copy the file contents
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `file_handle` or `buffer` is
+ * `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_buffer_from_file(
@@ -315,6 +319,8 @@ sxbp_result_t sxbp_buffer_from_file(
  * @param[out] file_handle The file to write data to
  * @returns `SXBP_RESULT_OK` on successfully writing the file
  * @returns `SXBP_RESULT_FAIL_FILE` on failure to write the file
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `buffer` or `file_handle` is
+ * `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_buffer_to_file(
@@ -340,6 +346,7 @@ sxbp_figure_t sxbp_blank_figure(void);
  * @returns `SXBP_RESULT_OK` if all memory was allocated successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if any memory was not allocated
  * successfully
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure);
@@ -369,6 +376,7 @@ bool sxbp_free_figure(sxbp_figure_t* const figure);
  * @returns `SXBP_RESULT_OK` if the data was copied successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the data was not copied successfully,
  * in which case `to` will be empty.
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `from` or `to` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_copy_figure(
@@ -392,6 +400,7 @@ sxbp_bitmap_t sxbp_blank_bitmap(void);
  * been allocated
  * @returns `SXBP_RESULT_OK` if memory was allocated successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if memory was not allocated successfully
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `bitmap` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap);
@@ -420,6 +429,7 @@ bool sxbp_free_bitmap(sxbp_bitmap_t* const bitmap);
  * @returns `SXBP_RESULT_OK` if the data was copied successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the data was not copied successfully,
  * in which case `to` will be empty.
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `from` or `to` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_copy_bitmap(
@@ -447,6 +457,7 @@ sxbp_result_t sxbp_copy_bitmap(
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the figure could not be successfully
  * generated
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if the given buffer was too large
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `data` or `figure` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_begin_figure(
@@ -470,6 +481,7 @@ sxbp_result_t sxbp_begin_figure(
  * allocated
  * @returns `SXBP_RESULT_FAIL_MEMORY` if a memory allocation error occurred when
  * refining the figure
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_refine_figure(
@@ -487,6 +499,7 @@ sxbp_result_t sxbp_refine_figure(
  * @returns `SXBP_RESULT_OK` if the figure could be successfully serialised
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the figure could not be successfully
  * serialised
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `buffer` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_dump_figure(
@@ -508,6 +521,7 @@ sxbp_result_t sxbp_dump_figure(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if the figure could not be
  * deserialised because the buffer contains invalid data or data for a version
  * of SXBP that this version cannot read
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `buffer` or `figure` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_load_figure(
@@ -525,6 +539,7 @@ sxbp_result_t sxbp_load_figure(
  * @returns `SXBP_RESULT_OK` if the figure could be rendered successfully
  * @returns `SXBP_RESULT_FAIL_MEMORY` if the figure could not be rendered
  * successfully
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `bitmap` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_render_figure(

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -110,6 +110,9 @@ sxbp_result_t sxbp_make_bitmap_for_bounds(
 // private, prints out a bitmap to the given stream, for debugging
 void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream);
 
+// private, macro to assist in 'return early if NULL pointer' error checks
+#define SXBP_RETURN_FAIL_IF_NULL(pointer) if (pointer == NULL) return SXBP_RESULT_FAIL_PRECONDITION
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "sxbp.h"
+#include "sxbp_internal.h"
 
 
 #ifdef __cplusplus
@@ -49,6 +50,8 @@ sxbp_buffer_t sxbp_blank_buffer(void) {
 }
 
 sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer) {
+    // check buffer isn't NULL
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
     // allocate memory with calloc to make sure all bytes are set to zero
     buffer->bytes = calloc(buffer->size, sizeof(uint8_t));
     // if bytes is not NULL, then the operation was successful
@@ -56,8 +59,8 @@ sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer) {
 }
 
 bool sxbp_free_buffer(sxbp_buffer_t* const buffer) {
-    // if bytes is not NULL, assume there's memory to be deallocated
-    if (buffer->bytes != NULL) {
+    // if buffer and bytes are not NULL, assume there's memory to be deallocated
+    if (buffer != NULL && buffer->bytes != NULL) {
         free(buffer->bytes);
         // set bytes to NULL (be a good person)
         buffer->bytes = NULL;
@@ -72,6 +75,9 @@ sxbp_result_t sxbp_copy_buffer(
     const sxbp_buffer_t* const from,
     sxbp_buffer_t* const to
 ) {
+    // check both pointers to ensure they're not NULL
+    SXBP_RETURN_FAIL_IF_NULL(from);
+    SXBP_RETURN_FAIL_IF_NULL(to);
     // before we do anything else, make sure 'to' has been freed
     sxbp_free_buffer(to);
     // copy across the size
@@ -106,6 +112,9 @@ sxbp_result_t sxbp_buffer_from_file(
     FILE* file_handle,
     sxbp_buffer_t* const buffer
 ) {
+    // check both pointers to ensure they're not NULL
+    SXBP_RETURN_FAIL_IF_NULL(file_handle);
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
     // erase buffer
     sxbp_free_buffer(buffer);
     // get the file's size
@@ -142,6 +151,9 @@ sxbp_result_t sxbp_buffer_to_file(
     const sxbp_buffer_t* const buffer,
     FILE* file_handle
 ) {
+    // check both pointers to ensure they're not NULL
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
+    SXBP_RETURN_FAIL_IF_NULL(file_handle);
     // try and write the file contents
     size_t bytes_written = fwrite(
         buffer->bytes,
@@ -158,6 +170,8 @@ sxbp_figure_t sxbp_blank_figure(void) {
 }
 
 sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure) {
+    // check figure isn't NULL
+    SXBP_RETURN_FAIL_IF_NULL(figure);
     // allocate the lines, using calloc to set all fields of each one to zero
     figure->lines = calloc(figure->size, sizeof(sxbp_line_t));
     // if lines is not NULL, then the operation was successful
@@ -165,8 +179,8 @@ sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure) {
 }
 
 bool sxbp_free_figure(sxbp_figure_t* const figure) {
-    // if lines is not NULL, assume there's memory to be deallocated
-    if (figure->lines != NULL) {
+    // if figure and lines are not NULL, assume there's memory to be deallocated
+    if (figure != NULL && figure->lines != NULL) {
         free(figure->lines);
         // set lines to NULL (be a good person)
         figure->lines = NULL;
@@ -181,6 +195,9 @@ sxbp_result_t sxbp_copy_figure(
     const sxbp_figure_t* const from,
     sxbp_figure_t* const to
 ) {
+    // check both pointers to ensure they're not NULL
+    SXBP_RETURN_FAIL_IF_NULL(from);
+    SXBP_RETURN_FAIL_IF_NULL(to);
     // before we do anything else, make sure 'to' has been freed
     sxbp_free_figure(to);
     // copy across the static members
@@ -210,6 +227,8 @@ static bool sxbp_init_bitmap_col(bool** col, uint32_t size) {
 }
 
 sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap) {
+    // check bitmap isn't NULL
+    SXBP_RETURN_FAIL_IF_NULL(bitmap);
     // first allocate pointers for the columns
     bitmap->pixels = calloc(bitmap->width, sizeof(bool*));
     if (bitmap->pixels == NULL) {
@@ -234,8 +253,8 @@ sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap) {
 }
 
 bool sxbp_free_bitmap(sxbp_bitmap_t* const bitmap) {
-    // if pixels is not NULL, assume there are cols to be deallocated
-    if (bitmap->pixels != NULL) {
+    // if bitmap and pixels aren't NULL, assume there are cols to be deallocated
+    if (bitmap != NULL && bitmap->pixels != NULL) {
         // deallocate each col that needs deallocating first
         for (uint32_t col = 0; col < bitmap->width; col++) {
             if (bitmap->pixels[col] != NULL) {
@@ -254,6 +273,9 @@ sxbp_result_t sxbp_copy_bitmap(
     const sxbp_bitmap_t* const from,
     sxbp_bitmap_t* const to
 ) {
+    // check both pointers to ensure they're not NULL
+    SXBP_RETURN_FAIL_IF_NULL(from);
+    SXBP_RETURN_FAIL_IF_NULL(to);
     // before we do anything else, make sure 'to' has been freed
     sxbp_free_bitmap(to);
     // copy across width and height

--- a/tests.c
+++ b/tests.c
@@ -8,6 +8,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include <assert.h>
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -43,6 +44,24 @@ static void print_progress(const sxbp_figure_t* figure, void* context) {
 
 int main(void) {
     printf("This is SXBP v%s\n", SXBP_VERSION.string);
+    // test that the public API is resistant to NULL-pointer-deref errors
+    assert(sxbp_init_buffer(NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_free_buffer(NULL) == false);
+    assert(sxbp_copy_buffer(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_buffer_from_file(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_buffer_to_file(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_init_figure(NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_free_figure(NULL) == false);
+    assert(sxbp_copy_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_init_bitmap(NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_free_bitmap(NULL) == false);
+    assert(sxbp_copy_bitmap(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_begin_figure(NULL, NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_refine_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_dump_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_load_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(sxbp_render_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    // now test normal usage of the public API
     const char* string = "SXBP";
     size_t length = strlen(string);
     sxbp_buffer_t buffer = { .size = length, .bytes = NULL, };


### PR DESCRIPTION
The public functions of the library now check that required pointer arguments aren't `NULL` before using them, returning early from the functions if they are.

Closes #207