### PR TITLE
Implement separation of figure-solving methods

### DIFF
--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -25,159 +25,25 @@
 extern "C" {
 #endif
 
-// private datatype for passing context data into sxbp_walk_figure() callback
-typedef struct figure_collides_context {
-    sxbp_bitmap_t* image;
-    bool* collided;
-} figure_collides_context;
-
-// private, callback function for sxbp_figure_collides()
-static bool sxbp_figure_collides_callback(sxbp_co_ord_t location, void* data) {
-    // cast void pointer to a pointer to our context structure
-    figure_collides_context* callback_data = (figure_collides_context*)data;
-    // check if there's already a pixel here
-    if (callback_data->image->pixels[location.x][location.y] == false) {
-        // if not, plot it
-        callback_data->image->pixels[location.x][location.y] = true;
-        // return true to tell the walk function that we want to continue
-        return true;
-    } else {
-        // otherwise, set collided to true to mark collision
-        *callback_data->collided = true;
-        // return false to tell the walk function to stop early
-        return false;
-    }
-}
-
-// private, sets collided to true if the figure's line collides with itself
-static sxbp_result_t sxbp_figure_collides(
-    const sxbp_figure_t* figure,
-    bool* collided
-) {
-    // get figure bounds first
-    sxbp_bounds_t bounds = sxbp_get_bounds(figure, 1);
-    // build bitmap for bounds
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
-    if (!sxbp_success(sxbp_make_bitmap_for_bounds(bounds, &bitmap))) {
-        // a memory allocation error occurred
-        return SXBP_RESULT_FAIL_MEMORY;
-    } else {
-        // construct callback context data
-        figure_collides_context data = {
-            .image = &bitmap, .collided = collided,
-        };
-        // set collided to false initially
-        *data.collided = false;
-        // begin walking the figure, use our callback function to handle points
-        sxbp_walk_figure(figure, 1, sxbp_figure_collides_callback, (void*)&data);
-        // free the memory allocated for the bitmap
-        sxbp_free_bitmap(&bitmap);
-        return SXBP_RESULT_OK;
-    }
-}
-
-/*
- * private, attempts to shorten the line of the figure at index l
- * if it succeeds, it will call itself recursively for each line after l from
- * max to l, in that order.
- */
-static sxbp_result_t sxbp_attempt_line_shorten(
-    sxbp_figure_t* figure,
-    const sxbp_figure_size_t l,
-    const sxbp_figure_size_t max
-) {
-    sxbp_line_t* line = &figure->lines[l];
-    // it only makes sense to try and shorten lines longer than 1
-    if (line->length > 1) {
-        // we'll need this later to check if we were actually able to shorten it
-        sxbp_length_t original_length = line->length;
-        // as an ambitious first step, set to 1 (try best case scenario first)
-        line->length = 1;
-        // check if it collided
-        bool collided = false;
-        // we'll store any errors encountered by this function here
-        sxbp_result_t status = SXBP_RESULT_UNKNOWN;
-        if (!sxbp_check(sxbp_figure_collides(figure, &collided), &status)) {
-            // handle error
-            return status;
-        } else {
-            /*
-             * if that caused a collision, keep extending it until it no longer
-             * collides (or we reach the original length)
-             * --we can quit in that case as we already know it doesn't collide
-             */
-            while (line->length < original_length && collided) {
-                line->length++;
-                // check again if it colldes and handle any errors
-                if (
-                    !sxbp_check(
-                        sxbp_figure_collides(figure, &collided), &status
-                    )
-                ) {
-                    // handle error
-                    return status;
-                }
-            }
-            /*
-             * at this point, the shape now no longer collides. now, we check to
-             * see if we were able to shorten the line at all. If so, we then
-             * try and shorten the lines after this one, in reverse order.
-             */
-            if (line->length < original_length) {
-                // try and shorten other lines some more
-                for (sxbp_figure_size_t i = max; i >= l; i--) {
-                    // handle any errors returned by the call
-                    if (
-                        !sxbp_check(
-                            sxbp_attempt_line_shorten(figure, i, max), &status
-                        )
-                    ) {
-                        return status;
-                    }
-                }
-            }
-        }
-    }
-    return SXBP_RESULT_OK;
-}
-
 sxbp_result_t sxbp_refine_figure(
     sxbp_figure_t* figure,
     const sxbp_refine_figure_options_t* options
 ) {
-    // figure must not be NULL
+    // figure and figure's lines must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(figure);
-    // we can't refine a figure that has no lines allocated, so check this first
-    if (figure->lines == NULL) {
-        // bail early, we can't do anything with this
-        return SXBP_RESULT_FAIL_PRECONDITION;
-    } else {
-        // variable to store any errors in
-        sxbp_result_t status = SXBP_RESULT_UNKNOWN;
-        // iterate over lines backwards - we don't care about line 0
-        for (sxbp_figure_size_t i = figure->size - 1; i > 0; i--) {
-            // try and shorten it, or return error if not
-            if (
-                !sxbp_check(
-                    sxbp_attempt_line_shorten(figure, i, figure->size - 1),
-                    &status
-                )
-            ) {
-                return status;
-            } else {
-                /*
-                 * set which how many lines we have left to solve
-                 * NOTE: this value is -1 because line 0 never needs solving
-                 */
-                figure->lines_remaining = i - 1;
-                // call the progress callback if it's been given
-                if (options != NULL && options->progress_callback != NULL) {
-                    options->progress_callback(figure, options->callback_context);
-                }
-            }
-        }
-        // signal to caller that the call succeeded
-        return SXBP_RESULT_OK;
+    SXBP_RETURN_FAIL_IF_NULL(figure->lines);
+    // work out which refinement method to use
+    sxbp_refine_method_t method = SXBP_REFINE_METHOD_DEFAULT;
+    if (options != NULL && options->refine_method != SXBP_REFINE_METHOD_ANY) {
+        method = options->refine_method;
+    }
+    // now run the appropriate refinement function for all implemented methods
+    switch (method) {
+        case SXBP_REFINE_METHOD_SHRINK_FROM_END:
+            return sxbp_refine_figure_shrink_from_end(figure, options);
+        default:
+            // an unimplemented refinement method was requested
+            return SXBP_RESULT_FAIL_UNIMPLEMENTED;
     }
 }
 

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -1,0 +1,178 @@
+/*
+ * This source file forms part of sxbp, a library which generates experimental
+ * 2D spiral-like shapes based on input binary data.
+ *
+ * This compilation unit provides the definition of `sxbp_refine_figure`, a
+ * public function used to shorten the lines of an SXBP figure to something less
+ * space-consuming, while still maintaining a pattern that has no collisions
+ * between lines.
+ *
+ * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "sxbp.h"
+#include "sxbp_internal.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// private datatype for passing context data into sxbp_walk_figure() callback
+typedef struct figure_collides_context {
+    sxbp_bitmap_t* image;
+    bool* collided;
+} figure_collides_context;
+
+// private, callback function for sxbp_figure_collides()
+static bool sxbp_figure_collides_callback(sxbp_co_ord_t location, void* data) {
+    // cast void pointer to a pointer to our context structure
+    figure_collides_context* callback_data = (figure_collides_context*)data;
+    // check if there's already a pixel here
+    if (callback_data->image->pixels[location.x][location.y] == false) {
+        // if not, plot it
+        callback_data->image->pixels[location.x][location.y] = true;
+        // return true to tell the walk function that we want to continue
+        return true;
+    } else {
+        // otherwise, set collided to true to mark collision
+        *callback_data->collided = true;
+        // return false to tell the walk function to stop early
+        return false;
+    }
+}
+
+// private, sets collided to true if the figure's line collides with itself
+static sxbp_result_t sxbp_figure_collides(
+    const sxbp_figure_t* figure,
+    bool* collided
+) {
+    // get figure bounds first
+    sxbp_bounds_t bounds = sxbp_get_bounds(figure, 1);
+    // build bitmap for bounds
+    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    if (!sxbp_success(sxbp_make_bitmap_for_bounds(bounds, &bitmap))) {
+        // a memory allocation error occurred
+        return SXBP_RESULT_FAIL_MEMORY;
+    } else {
+        // construct callback context data
+        figure_collides_context data = {
+            .image = &bitmap, .collided = collided,
+        };
+        // set collided to false initially
+        *data.collided = false;
+        // begin walking the figure, use our callback function to handle points
+        sxbp_walk_figure(figure, 1, sxbp_figure_collides_callback, (void*)&data);
+        // free the memory allocated for the bitmap
+        sxbp_free_bitmap(&bitmap);
+        return SXBP_RESULT_OK;
+    }
+}
+
+/*
+ * private, attempts to shorten the line of the figure at index l
+ * if it succeeds, it will call itself recursively for each line after l from
+ * max to l, in that order.
+ */
+static sxbp_result_t sxbp_attempt_line_shorten(
+    sxbp_figure_t* figure,
+    const sxbp_figure_size_t l,
+    const sxbp_figure_size_t max
+) {
+    sxbp_line_t* line = &figure->lines[l];
+    // it only makes sense to try and shorten lines longer than 1
+    if (line->length > 1) {
+        // we'll need this later to check if we were actually able to shorten it
+        sxbp_length_t original_length = line->length;
+        // as an ambitious first step, set to 1 (try best case scenario first)
+        line->length = 1;
+        // check if it collided
+        bool collided = false;
+        // we'll store any errors encountered by this function here
+        sxbp_result_t status = SXBP_RESULT_UNKNOWN;
+        if (!sxbp_check(sxbp_figure_collides(figure, &collided), &status)) {
+            // handle error
+            return status;
+        } else {
+            /*
+             * if that caused a collision, keep extending it until it no longer
+             * collides (or we reach the original length)
+             * --we can quit in that case as we already know it doesn't collide
+             */
+            while (line->length < original_length && collided) {
+                line->length++;
+                // check again if it colldes and handle any errors
+                if (
+                    !sxbp_check(
+                        sxbp_figure_collides(figure, &collided), &status
+                    )
+                ) {
+                    // handle error
+                    return status;
+                }
+            }
+            /*
+             * at this point, the shape now no longer collides. now, we check to
+             * see if we were able to shorten the line at all. If so, we then
+             * try and shorten the lines after this one, in reverse order.
+             */
+            if (line->length < original_length) {
+                // try and shorten other lines some more
+                for (sxbp_figure_size_t i = max; i >= l; i--) {
+                    // handle any errors returned by the call
+                    if (
+                        !sxbp_check(
+                            sxbp_attempt_line_shorten(figure, i, max), &status
+                        )
+                    ) {
+                        return status;
+                    }
+                }
+            }
+        }
+    }
+    return SXBP_RESULT_OK;
+}
+
+sxbp_result_t sxbp_refine_figure_shrink_from_end(
+    sxbp_figure_t* figure,
+    const sxbp_refine_figure_options_t* options
+) {
+    // variable to store any errors in
+    sxbp_result_t status = SXBP_RESULT_UNKNOWN;
+    // iterate over lines backwards - we don't care about line 0
+    for (sxbp_figure_size_t i = figure->size - 1; i > 0; i--) {
+        // try and shorten it, or return error if not
+        if (
+            !sxbp_check(
+                sxbp_attempt_line_shorten(figure, i, figure->size - 1),
+                &status
+            )
+        ) {
+            return status;
+        } else {
+            /*
+             * set which how many lines we have left to solve
+             * NOTE: this value is -1 because line 0 never needs solving
+             */
+            figure->lines_remaining = i - 1;
+            // call the progress callback if it's been given
+            if (options != NULL && options->progress_callback != NULL) {
+                options->progress_callback(figure, options->callback_context);
+            }
+        }
+    }
+    // signal to caller that the call succeeded
+    return SXBP_RESULT_OK;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/sxbp/sxbp.c
+++ b/sxbp/sxbp.c
@@ -33,6 +33,9 @@ const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT = {
     .max_lines = 0,
 };
 
+const sxbp_refine_method_t SXBP_REFINE_METHOD_DEFAULT =
+    SXBP_REFINE_METHOD_SHRINK_FROM_END;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -149,7 +149,7 @@ typedef struct sxbp_begin_figure_options_t {
  * @since v0.54.0
  */
 typedef enum sxbp_refine_method_t {
-    SXBP_REFINE_METHOD_UNKNOWN = 0u, /**< unknown, the default */
+    SXBP_REFINE_METHOD_ANY = 0u, /**< use any method, the default */
     SXBP_REFINE_METHOD_GROW_FROM_START, /**< the original refinement method */
     SXBP_REFINE_METHOD_SHRINK_FROM_END, /**< the current refinement method */
     SXBP_REFINE_METHOD_GROW_FROM_MIDDLE = 10u, /**< reserved for future use */
@@ -219,6 +219,7 @@ typedef enum sxbp_result_t {
     SXBP_RESULT_FAIL_MEMORY, /**< failure to allocate or reallocate memory */
     SXBP_RESULT_FAIL_PRECONDITION, /**< a preconditional check failed */
     SXBP_RESULT_FAIL_FILE, /**< a file read/write operation failed */
+    SXBP_RESULT_FAIL_UNIMPLEMENTED, /** requested action is not implemented */
     SXBP_RESULT_RESERVED_START, /**< reserved for future use */
     SXBP_RESULT_RESERVED_END = 255u, /**< reserved for future use */
 } sxbp_result_t;
@@ -507,11 +508,13 @@ sxbp_result_t sxbp_begin_figure(
  * to it has colliding lines, or no lines
  * @warning This function may take a long time to execute
  * @returns `SXBP_RESULT_OK` if the figure could be successfully refined
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` is `NULL`
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if called on a figure with no lines
  * allocated
+ * @returns `SXBP_RESULT_FAIL_UNIMPLEMENTED` if `options` specifies an
+ * unimplemented refinement method.
  * @returns `SXBP_RESULT_FAIL_MEMORY` if a memory allocation error occurred when
  * refining the figure
- * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` is `NULL`
  * @since v0.54.0
  */
 sxbp_result_t sxbp_refine_figure(

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -64,10 +64,10 @@ typedef struct sxbp_buffer_t {
  * @since v0.54.0
  */
 typedef enum sxbp_direction_t {
-    SXBP_UP = 0, /**< The cartesian direction 'UP' */
-    SXBP_RIGHT = 1, /**< The cartesian direction 'RIGHT' */
-    SXBP_DOWN = 2, /**< The cartesian direction 'DOWN' */
-    SXBP_LEFT = 3, /**< The cartesian direction 'LEFT' */
+    SXBP_UP = 0u, /**< The cartesian direction 'UP' */
+    SXBP_RIGHT = 1u, /**< The cartesian direction 'RIGHT' */
+    SXBP_DOWN = 2u, /**< The cartesian direction 'DOWN' */
+    SXBP_LEFT = 3u, /**< The cartesian direction 'LEFT' */
 } sxbp_direction_t;
 
 /**
@@ -137,10 +137,35 @@ typedef struct sxbp_begin_figure_options_t {
 } sxbp_begin_figure_options_t;
 
 /**
+ * @brief Used to specify which figure refinement method should be used
+ * @details There are a few different ways that a figure can be 'refined' to be
+ * smaller, this type is used to represent all of the methods currently
+ * implemented by the library
+ * @note Values `SXBP_REFINE_METHOD_RESERVED_START` through
+ * `SXBP_REFINE_METHOD_RESERVED_END` inclusive are reserved for future use.
+ * If a value equal to or greater than `SXBP_REFINE_METHOD_RESERVED_START` is
+ * encountered, the caller can assume that either a new code for which it has no
+ * definition has been returned, or that the value is garbage.
+ * @since v0.54.0
+ */
+typedef enum sxbp_refine_method_t {
+    SXBP_REFINE_METHOD_UNKNOWN = 0u, /**< unknown, the default */
+    SXBP_REFINE_METHOD_GROW_FROM_START, /**< the original refinement method */
+    SXBP_REFINE_METHOD_SHRINK_FROM_END, /**< the current refinement method */
+    SXBP_REFINE_METHOD_GROW_FROM_MIDDLE = 10u, /**< reserved for future use */
+    SXBP_REFINE_METHOD_RESERVED_START, /**< reserved for future use */
+    SXBP_REFINE_METHOD_RESERVED_END = 255u, /**< reserved for future use */
+} sxbp_refine_method_t;
+
+/**
  * @brief A structure used for providing options to `sxbp_refine_figure()`
  * @since v0.54.0
  */
 typedef struct sxbp_refine_figure_options_t {
+    /**
+     * @begin The method to be used to refine the figure
+     */
+    sxbp_refine_method_t refine_method;
     /**
      * @brief An optional callback to be called every time a new line is solved.
      */
@@ -218,6 +243,11 @@ extern const size_t SXBP_BEGIN_BUFFER_MAX_SIZE;
  * @brief The default options used for `sxbp_begin_figure()`
  */
 extern const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;
+
+/**
+ * @brief The default figure refinement method used by `sxbp_refine_figure()`
+ */
+extern const sxbp_refine_method_t SXBP_REFINE_METHOD_DEFAULT;
 
 /**
  * @brief Returns if a given `sxbp_result_t` is successful or not

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -110,6 +110,12 @@ sxbp_result_t sxbp_make_bitmap_for_bounds(
 // private, prints out a bitmap to the given stream, for debugging
 void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream);
 
+// private, refines a figure using the 'shrink from end' method
+sxbp_result_t sxbp_refine_figure_shrink_from_end(
+    sxbp_figure_t* figure,
+    const sxbp_refine_figure_options_t* options
+);
+
 // private, macro to assist in 'return early if NULL pointer' error checks
 #define SXBP_RETURN_FAIL_IF_NULL(pointer) if (pointer == NULL) return SXBP_RESULT_FAIL_PRECONDITION
 

--- a/tests.c
+++ b/tests.c
@@ -78,7 +78,7 @@ int main(void) {
         sxbp_refine_figure_options_t options = {
             .progress_callback = print_progress,
         };
-        sxbp_refine_figure(&figure, &options);
+        assert(sxbp_refine_figure(&figure, &options) == SXBP_RESULT_OK);
         // render complete figure to bitmap
         sxbp_render_figure(&figure, &bitmap);
         sxbp_free_figure(&figure);


### PR DESCRIPTION
There's currently just one implemented method, but these changes now allow different methods to be used to solve figures in the future. This could even (and should) be exposed as a command-line argument for maximum flexibility and power.
Closes #213