### PR TITLE
Add rendering of PBM images

### DIFF
--- a/sxbp/render_figure.c
+++ b/sxbp/render_figure.c
@@ -1,0 +1,48 @@
+/*
+ * This source file forms part of sxbp,
+ a library which generates experimental
+ * 2D spiral-like shapes based on input binary data.
+ *
+ * This compilation unit provides the definition of
+ * `sxbp_render_figure`, a public function used to render an SXBP figure to an
+ * image of its shape, using a user-specified rendering callback.
+ *
+ * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <stdbool.h>
+
+#include "sxbp.h"
+#include "sxbp_internal.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+sxbp_result_t sxbp_render_figure(
+    const sxbp_figure_t* const figure,
+    sxbp_buffer_t* const buffer,
+    sxbp_figure_renderer_t render_callback,
+    const sxbp_render_options_t* const render_options,
+    const void* render_callback_options
+) {
+    // figure, buffer and render_callback must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(figure);
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
+    SXBP_RETURN_FAIL_IF_NULL(render_callback);
+    // use the callback to render the figure
+    return render_callback(
+        figure,
+        buffer,
+        render_options,
+        render_callback_options
+    );
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -2,8 +2,9 @@
  * This source file forms part of sxbp, a library which generates experimental
  * 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides the definition of `sxbp_render_figure`, a
- * public function used to render an SXBP figure to a basic bitmap structure.
+ * This compilation unit provides the definition of
+ * `sxbp_render_figure_to_bitmap`, a public function used to render an SXBP
+ * figure to a basic bitmap structure.
  *
  * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
  *
@@ -22,7 +23,7 @@ extern "C" {
 #endif
 
 // private datatype for passing context data into sxbp_walk_figure() callback
-typedef struct render_figure_context {
+typedef struct render_figure_to_bitmap_context {
     sxbp_bitmap_t* image; // the bitmap to draw to
     /*
      * the following unusual fields facilitate a low-tech way of skipping the
@@ -30,15 +31,15 @@ typedef struct render_figure_context {
      */
     bool first_pixel_complete; // whether the first pixel has been plotted yet
     bool second_pixel_complete; // whether the second pixel has been plotted yet
-} render_figure_context;
+} render_figure_to_bitmap_context;
 
-// private, callback function for sxbp_render_figure()
-static bool sxbp_render_figure_callback(
+// private, callback function for sxbp_render_figure_to_bitmap()
+static bool sxbp_render_figure_to_bitmap_callback(
     sxbp_co_ord_t location,
     void* callback_data
 ) {
     // cast void pointer to a pointer to our context structure
-    render_figure_context* data = (render_figure_context*)callback_data;
+    render_figure_to_bitmap_context* data = (render_figure_to_bitmap_context*)callback_data;
     // skip the plotting of the second pixel
     if (data->first_pixel_complete && !data->second_pixel_complete) {
         // mark second pixel as complete
@@ -53,7 +54,7 @@ static bool sxbp_render_figure_callback(
     return true;
 }
 
-sxbp_result_t sxbp_render_figure(
+sxbp_result_t sxbp_render_figure_to_bitmap(
     const sxbp_figure_t* figure,
     sxbp_bitmap_t* bitmap
 ) {
@@ -70,13 +71,18 @@ sxbp_result_t sxbp_render_figure(
         return SXBP_RESULT_FAIL_MEMORY;
     } else {
         // construct callback context data
-        render_figure_context data = {
+        render_figure_to_bitmap_context data = {
             .image = bitmap,
             .first_pixel_complete = false,
             .second_pixel_complete = false,
         };
         // walk the figure at scale 2, handle pixel plotting with callback
-        sxbp_walk_figure(figure, 2, sxbp_render_figure_callback, (void*)&data);
+        sxbp_walk_figure(
+            figure,
+            2,
+            sxbp_render_figure_to_bitmap_callback,
+            (void*)&data
+        );
     }
     return SXBP_RESULT_OK;
 }

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -47,8 +47,8 @@ static bool sxbp_render_figure_to_bitmap_callback(
     } else {
         // mark first pixel as complete if it isn't already
         data->first_pixel_complete = true;
-        // plot the pixel
-        data->image->pixels[location.x][location.y] = true;
+        // plot the pixel, but flip the y coördinate
+        data->image->pixels[location.x][data->image->height - 1 - location.y] = true;
     }
     // return true --we always want to continue
     return true;

--- a/sxbp/render_figure_to_null.c
+++ b/sxbp/render_figure_to_null.c
@@ -1,0 +1,43 @@
+/*
+ * This source file forms part of sxbp, a library which generates experimental
+ * 2D spiral-like shapes based on input binary data.
+ *
+ * This compilation unit provides the definition of
+ * `sxbp_render_figure_to_bitmap`, a public function used to render an SXBP
+ * figure to a basic bitmap structure.
+ *
+ * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <stdbool.h>
+
+#include "sxbp.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * disable GCC warning about unused parameters, as this dummy function doesn't
+ * do anything with its arguments
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+sxbp_result_t sxbp_render_to_null(
+    const sxbp_figure_t* const figure,
+    sxbp_buffer_t* const buffer,
+    const sxbp_render_options_t* const render_options,
+    const void* render_callback_options
+) {
+    return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+}
+// reënable all warnings
+#pragma GCC diagnostic pop
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/sxbp/render_figure_to_pbm.c
+++ b/sxbp/render_figure_to_pbm.c
@@ -2,8 +2,8 @@
  * This source file forms part of sxbp, a library which generates experimental
  * 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides the definition of `sxbp_render_figure_to_null`
- * , a dummy renderer callback function that does nothing.
+ * This compilation unit provides the definition of `sxbp_render_figure_to_pbm`,
+ * a public function used to render an SXBP figure to a PBM file buffer.
  *
  * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
  *
@@ -26,7 +26,7 @@ extern "C" {
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-sxbp_result_t sxbp_render_figure_to_null(
+sxbp_result_t sxbp_render_figure_to_pbm(
     const sxbp_figure_t* const figure,
     sxbp_buffer_t* const buffer,
     const sxbp_render_options_t* const render_options,

--- a/sxbp/render_figure_to_pbm.c
+++ b/sxbp/render_figure_to_pbm.c
@@ -11,18 +11,164 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include <inttypes.h>
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "sxbp.h"
+#include "sxbp_internal.h"
 
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// private, works out how many bytes are needed to store the given bitmap as PBM
+static size_t sxbp_get_pbm_image_size(
+    size_t width,
+    size_t height,
+    size_t width_string_length,
+    size_t height_string_length,
+    size_t* bytes_per_row
+) {
+    // calculate number of bytes per row - this is ceiling(width / 8)
+    *bytes_per_row = (size_t)ceil((double)width / 8.0);
+    // calculate number of bytes for the entire image pixels (rows and columns)
+    size_t image_bytes = *bytes_per_row * height;
+    // finally put it all together to get total image buffer size
+    return (
+        3 // "P4" magic number + whitespace
+        + width_string_length + 1 // width of image in decimal + whitespace
+        + height_string_length + 1 // height of image in decimal + whitespace
+        + image_bytes // lastly, the bytes which make up the image pixels
+    );
+}
+
+// private, tries to allocate data for the whole image and writes the header
+static sxbp_result_t sxbp_write_pbm_header(
+    const sxbp_bitmap_t* const bitmap,
+    sxbp_buffer_t* const buffer,
+    size_t* bytes_per_row_ptr,
+    size_t* index_ptr
+) {
+    sxbp_result_t error;
+    /*
+     * allocate two char arrays for the width and height strings - these may be
+     * up to 10 characters each (max uint32_t is 10 digits long), so allocate 2
+     * char arrays of 11 chars each (1 extra char for null-terminator)
+     */
+    char width_string[11], height_string[11];
+    // these are used to keep track of how many digits each is
+    int width_string_length, height_string_length = 0;
+    // convert width and height to a decimal string, store lengths
+    width_string_length = sprintf(width_string, "%" PRIu32, bitmap->width);
+    height_string_length = sprintf(height_string, "%" PRIu32, bitmap->height);
+    /*
+     * now that we know the length of the image dimension strings, we can now
+     * calculate how much memory we'll have to allocate for the image buffer
+     */
+    buffer->size = sxbp_get_pbm_image_size(
+        bitmap->width,
+        bitmap->height,
+        width_string_length,
+        height_string_length,
+        bytes_per_row_ptr
+    );
+    // try and allocate the buffer
+    if (!sxbp_check(sxbp_init_buffer(buffer), &error)) {
+        // catch and return error if there was one
+        return error;
+    } else {
+        // now with the buffer allocated, write the header
+        size_t index = *index_ptr; // this index is used to index the buffer
+        // construct magic number + whitespace
+        memcpy(buffer->bytes + index, "P4\n", 3);
+        index += 3;
+        // image width
+        memcpy(buffer->bytes + index, width_string, width_string_length);
+        index += width_string_length;
+        // whitespace
+        memcpy(buffer->bytes + index, "\n", 1);
+        index += 1;
+        // image height
+        memcpy(buffer->bytes + index, height_string, height_string_length);
+        index += height_string_length;
+        // whitespace
+        memcpy(buffer->bytes + index, "\n", 1);
+        index += 1;
+        // update the index pointer
+        *index_ptr = index;
+    }
+    return SXBP_RESULT_OK;
+}
+
+// private, writes the image data out to the buffer
+static void sxbp_write_pbm_data(
+    const sxbp_bitmap_t* const bitmap,
+    sxbp_buffer_t* const buffer,
+    size_t bytes_per_row,
+    size_t index
+) {
+    // now for the image data, packed into rows to the nearest byte
+    for(size_t y = 0; y < bitmap->height; y++) { // row loop
+        for(size_t x = 0; x < bitmap->width; x++) {
+            // byte index is index + floor(x / 8)
+            size_t byte_index = index + (x / 8);
+            // bit index is x mod 8
+            uint8_t bit_index = x % 8;
+            // write bits most-significant-bit first
+            buffer->bytes[byte_index] |= (
+                // black pixel = bool true = 1, just like in PBM format
+                bitmap->pixels[x][y] << (7 - bit_index)
+            );
+        }
+        // increment index so next row is written in the correct place
+        index += bytes_per_row;
+    }
+}
+
+// private, serialises a bitmap to PBM image data
+static sxbp_result_t sxbp_bitmap_to_pbm(
+    const sxbp_bitmap_t* const bitmap,
+    sxbp_buffer_t* const buffer
+) {
+    sxbp_result_t error;
+    // index into the image data
+    size_t index = 0;
+    // we'll use this later to track how many bytes we pack each row into
+    size_t bytes_per_row;
+    /*
+     * write the header first --this allocates the buffer to the size required
+     * to store the whole image data too
+     */
+    if (
+        !sxbp_check(
+            sxbp_write_pbm_header(
+                bitmap,
+                buffer,
+                &bytes_per_row,
+                &index
+            ),
+            &error
+        )
+    ) {
+        // catch and return error if there was one
+        return error;
+    } else {
+        // memory allocation successful, now write out the image data
+        sxbp_write_pbm_data(bitmap, buffer, bytes_per_row, index);
+    }
+    return SXBP_RESULT_OK;
+}
+
 /*
- * disable GCC warning about unused parameters, as this dummy function doesn't
- * do anything with its arguments
+ * disable GCC warning about unused parameters, as this render backend doesn't
+ * use all the arguments
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -32,7 +178,20 @@ sxbp_result_t sxbp_render_figure_to_pbm(
     const sxbp_render_options_t* const render_options,
     const void* render_callback_options
 ) {
-    return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+    // figure, figure lines and buffer must not be NULL
+    SXBP_RETURN_FAIL_IF_NULL(figure);
+    SXBP_RETURN_FAIL_IF_NULL(figure->lines);
+    SXBP_RETURN_FAIL_IF_NULL(buffer);
+    sxbp_result_t error;
+    // rasterise the figure to bitmap first of all
+    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    if (!sxbp_check(sxbp_render_figure_to_bitmap(figure, &bitmap), &error)) {
+        // catch and return raised error
+        return error;
+    } else {
+        // rasterisation was successful, now convert the raw bitmap to PBM
+        return sxbp_bitmap_to_pbm(&bitmap, buffer);
+    }
 }
 // reënable all warnings
 #pragma GCC diagnostic pop

--- a/sxbp/render_figure_to_pbm.c
+++ b/sxbp/render_figure_to_pbm.c
@@ -190,7 +190,10 @@ sxbp_result_t sxbp_render_figure_to_pbm(
         return error;
     } else {
         // rasterisation was successful, now convert the raw bitmap to PBM
-        return sxbp_bitmap_to_pbm(&bitmap, buffer);
+        sxbp_result_t outcome = sxbp_bitmap_to_pbm(&bitmap, buffer);
+        // free the bitmap and return the result code
+        sxbp_free_bitmap(&bitmap);
+        return outcome;
     }
 }
 // reënable all warnings

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -239,8 +239,8 @@ typedef enum sxbp_result_t {
  * @brief A convenience typedef for a callback function that renders a figure
  * @details This is used in `sxbp_render_figure()` and should render a figure to
  * an image, serialised and stored in the given buffer.
- * @todo Try and use Doxygen's `@param` syntax to document the arguments and
- * use `@returns` to document the return details.
+ * @todo Try and use Doxygen's `at-param` syntax to document the arguments and
+ * use `at-returns` to document the return details.
  */
 typedef sxbp_result_t(* sxbp_figure_renderer_t)(
     const sxbp_figure_t* const figure,

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -575,7 +575,7 @@ sxbp_result_t sxbp_load_figure(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `bitmap` is `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_render_figure(
+sxbp_result_t sxbp_render_figure_to_bitmap(
     const sxbp_figure_t* const figure,
     sxbp_bitmap_t* const bitmap
 );

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -627,13 +627,24 @@ sxbp_result_t sxbp_render_figure_to_bitmap(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure`, `buffer` or
  * `render_callback` is `NULL`
  * @returns Any other valid value for type `sxbp_result_t`, according to all
- * the possible error codes that can be returned by the render callback.
+ * the possible error codes that can be returned by the given render callback.
  * @since v0.54.0
  */
 sxbp_result_t sxbp_render_figure(
     const sxbp_figure_t* const figure,
     sxbp_buffer_t* const buffer,
     sxbp_figure_renderer_t render_callback,
+    const sxbp_render_options_t* const render_options,
+    const void* render_callback_options
+);
+
+/**
+ * @brief A dummy renderer function that does nothing
+ * @details This exists for testing purposes only
+ */
+sxbp_result_t sxbp_render_to_null(
+    const sxbp_figure_t* const figure,
+    sxbp_buffer_t* const buffer,
     const sxbp_render_options_t* const render_options,
     const void* render_callback_options
 );

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -580,6 +580,31 @@ sxbp_result_t sxbp_render_figure_to_bitmap(
     sxbp_bitmap_t* const bitmap
 );
 
+/**
+ * @brief Renders an image of the given figure, using the given render callback
+ * @details The render callback should write out the bytes of the rendered image
+ * to the given buffer.
+ * @note The buffer is erased before the output is written to it
+ * @param figure The SXBP figure to render
+ * @param render_callback A callback function which can render figures out to
+ * a specific image format, outputting the serialised image data to the given
+ * buffer
+ * @param[out] buffer The buffer to write the image data out to
+ * @returns `SXBP_RESULT_OK` if the figure could be rendered successfully
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `bitmap` is `NULL`
+ * @returns Any other valid value for type `sxbp_result_t`, according to all
+ * the possible error codes that can be returned by the render callback.
+ * @since v0.54.0
+ */
+sxbp_result_t sxbp_render_figure(
+    const sxbp_figure_t* const figure,
+    sxbp_result_t(* render_callback)(
+        const sxbp_figure_t* const figure,
+        sxbp_buffer_t* const buffer
+    ),
+    sxbp_buffer_t* const buffer
+);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -642,7 +642,7 @@ sxbp_result_t sxbp_render_figure(
  * @brief A dummy renderer function that does nothing
  * @details This exists for testing purposes only
  */
-sxbp_result_t sxbp_render_to_null(
+sxbp_result_t sxbp_render_figure_to_null(
     const sxbp_figure_t* const figure,
     sxbp_buffer_t* const buffer,
     const sxbp_render_options_t* const render_options,
@@ -652,7 +652,7 @@ sxbp_result_t sxbp_render_to_null(
 /**
  * @brief Renders figures to PBM images
  */
-sxbp_result_t sxbp_render_to_pbm(
+sxbp_result_t sxbp_render_figure_to_pbm(
     const sxbp_figure_t* const figure,
     sxbp_buffer_t* const buffer,
     const sxbp_render_options_t* const render_options,

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -184,6 +184,17 @@ typedef struct sxbp_refine_figure_options_t {
 } sxbp_refine_figure_options_t;
 
 /**
+ * @brief A structure used for providing options to `sxbp_render_figure()`
+ * @todo Add more options such as background and line colours (RGBA),
+ * alternative colour for the starting dot, etc...
+ * @since v0.54.0
+ */
+typedef struct sxbp_render_options_t {
+    /** @brief The scale factor to render the image to */
+    size_t scale;
+} sxbp_render_options_t;
+
+/**
  * @brief Used to represent a basic 1-bit, pure black/white bitmap image.
  * @details The image has integer height and width, and a 2-dimensional array of
  * 1-bit pixels which are either black or white.
@@ -223,6 +234,20 @@ typedef enum sxbp_result_t {
     SXBP_RESULT_RESERVED_START, /**< reserved for future use */
     SXBP_RESULT_RESERVED_END = 255u, /**< reserved for future use */
 } sxbp_result_t;
+
+/**
+ * @brief A convenience typedef for a callback function that renders a figure
+ * @details This is used in `sxbp_render_figure()` and should render a figure to
+ * an image, serialised and stored in the given buffer.
+ * @todo Try and use Doxygen's `@param` syntax to document the arguments and
+ * use `@returns` to document the return details.
+ */
+typedef sxbp_result_t(* sxbp_figure_renderer_t)(
+    const sxbp_figure_t* const figure,
+    sxbp_buffer_t* const buffer,
+    const sxbp_render_options_t* const render_options,
+    const void* render_callback_options
+);
 
 /**
  * @brief Stores the current version of sxbp.
@@ -586,23 +611,41 @@ sxbp_result_t sxbp_render_figure_to_bitmap(
  * to the given buffer.
  * @note The buffer is erased before the output is written to it
  * @param figure The SXBP figure to render
+ * @param[out] buffer The buffer to write the image data out to
  * @param render_callback A callback function which can render figures out to
  * a specific image format, outputting the serialised image data to the given
  * buffer
- * @param[out] buffer The buffer to write the image data out to
+ * @param render_options An optional pointer to options affecting the rendered
+ * output
+ * @param render_callback_options Optional type-agnostic pointer to additional
+ * options that are specific to this particular render callback.
+ * @warn No type-checking is done for `render_callback_options`, as the accepted
+ * type (if any) is entirely dependent on the render callback being used. Care
+ * must be taken to only pass a pointer to a type accepted by the used render
+ * callback.
  * @returns `SXBP_RESULT_OK` if the figure could be rendered successfully
- * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `bitmap` is `NULL`
+ * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure`, `buffer` or
+ * `render_callback` is `NULL`
  * @returns Any other valid value for type `sxbp_result_t`, according to all
  * the possible error codes that can be returned by the render callback.
  * @since v0.54.0
  */
 sxbp_result_t sxbp_render_figure(
     const sxbp_figure_t* const figure,
-    sxbp_result_t(* render_callback)(
-        const sxbp_figure_t* const figure,
-        sxbp_buffer_t* const buffer
-    ),
-    sxbp_buffer_t* const buffer
+    sxbp_buffer_t* const buffer,
+    sxbp_figure_renderer_t render_callback,
+    const sxbp_render_options_t* const render_options,
+    const void* render_callback_options
+);
+
+/**
+ * @brief Renders figures to PBM images
+ */
+sxbp_result_t sxbp_render_to_pbm(
+    const sxbp_figure_t* const figure,
+    sxbp_buffer_t* const buffer,
+    const sxbp_render_options_t* const render_options,
+    const void* render_callback_options
 );
 
 #ifdef __cplusplus

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -151,7 +151,7 @@ sxbp_result_t sxbp_make_bitmap_for_bounds(
 void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream) {
     for (sxbp_figure_size_t y = 0; y < bitmap->height; y++) {
         for (sxbp_figure_size_t x = 0; x < bitmap->width; x++) {
-            fprintf(stream, bitmap->pixels[x][bitmap->height - 1 - y] ? "█" : "░");
+            fprintf(stream, bitmap->pixels[x][y] ? "█" : "░");
         }
         fprintf(stream, "\n");
     }

--- a/tests.c
+++ b/tests.c
@@ -113,9 +113,11 @@ int main(void) {
         FILE* output_file = fopen("sxbp-test.pbm", "wb");
         assert(output_file != NULL);
         outcome = sxbp_buffer_to_file(&buffer, output_file);
-        assert(output_file != NULL);
+        assert(outcome == SXBP_RESULT_OK);
+        fclose(output_file);
         sxbp_free_figure(&figure);
         sxbp_free_bitmap(&bitmap);
+        sxbp_free_buffer(&buffer);
         return 0;
     }
 }

--- a/tests.c
+++ b/tests.c
@@ -72,7 +72,7 @@ int main(void) {
         == SXBP_RESULT_FAIL_PRECONDITION
     );
     // now test normal usage of the public API
-    const char* string = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+    const char* string = "sxbp";
     size_t length = strlen(string);
     sxbp_buffer_t buffer = { .size = length, .bytes = NULL, };
     if (!sxbp_init_buffer(&buffer)) {

--- a/tests.c
+++ b/tests.c
@@ -32,7 +32,7 @@ extern "C"{
 static void print_progress(const sxbp_figure_t* figure, void* context) {
     printf("%" PRIu32 "\n", figure->lines_remaining);
     sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
-    sxbp_render_figure(figure, &bitmap);
+    sxbp_render_figure_to_bitmap(figure, &bitmap);
     sxbp_print_bitmap(&bitmap, stdout);
     // free the memory, be a good person!
     sxbp_free_bitmap(&bitmap);
@@ -60,7 +60,10 @@ int main(void) {
     assert(sxbp_refine_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
     assert(sxbp_dump_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
     assert(sxbp_load_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
-    assert(sxbp_render_figure(NULL, NULL) == SXBP_RESULT_FAIL_PRECONDITION);
+    assert(
+        sxbp_render_figure_to_bitmap(NULL, NULL)
+        == SXBP_RESULT_FAIL_PRECONDITION
+    );
     // now test normal usage of the public API
     const char* string = "SXBP";
     size_t length = strlen(string);
@@ -74,14 +77,14 @@ int main(void) {
         sxbp_free_buffer(&buffer);
         // render incomplete figure to bitmap
         sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
-        sxbp_render_figure(&figure, &bitmap);
+        sxbp_render_figure_to_bitmap(&figure, &bitmap);
         sxbp_refine_figure_options_t options = {
             .progress_callback = print_progress,
         };
         sxbp_result_t outcome = sxbp_refine_figure(&figure, &options);
         assert(outcome == SXBP_RESULT_OK);
         // render complete figure to bitmap
-        sxbp_render_figure(&figure, &bitmap);
+        sxbp_render_figure_to_bitmap(&figure, &bitmap);
         sxbp_free_figure(&figure);
         sxbp_free_bitmap(&bitmap);
         return 0;

--- a/tests.c
+++ b/tests.c
@@ -64,7 +64,7 @@ int main(void) {
         == SXBP_RESULT_FAIL_PRECONDITION
     );
     assert(
-        sxbp_render_to_null(NULL, NULL, NULL, NULL)
+        sxbp_render_figure_to_null(NULL, NULL, NULL, NULL)
         == SXBP_RESULT_FAIL_UNIMPLEMENTED
     );
     // now test normal usage of the public API
@@ -87,7 +87,13 @@ int main(void) {
         sxbp_result_t outcome = sxbp_refine_figure(&figure, &options);
         assert(outcome == SXBP_RESULT_OK);
         // test null renderer can be called
-        sxbp_render_figure(&figure, &buffer, sxbp_render_to_null, NULL, NULL);
+        sxbp_render_figure(
+            &figure,
+            &buffer,
+            sxbp_render_figure_to_null,
+            NULL,
+            NULL
+        );
         // render complete figure to bitmap
         sxbp_render_figure_to_bitmap(&figure, &bitmap);
         printf("\n");

--- a/tests.c
+++ b/tests.c
@@ -63,6 +63,10 @@ int main(void) {
         sxbp_render_figure(NULL, NULL, NULL, NULL, NULL)
         == SXBP_RESULT_FAIL_PRECONDITION
     );
+    assert(
+        sxbp_render_to_null(NULL, NULL, NULL, NULL)
+        == SXBP_RESULT_FAIL_UNIMPLEMENTED
+    );
     // now test normal usage of the public API
     const char* string = "SXBP";
     size_t length = strlen(string);

--- a/tests.c
+++ b/tests.c
@@ -67,8 +67,12 @@ int main(void) {
         sxbp_render_figure_to_null(NULL, NULL, NULL, NULL)
         == SXBP_RESULT_FAIL_UNIMPLEMENTED
     );
+    assert(
+        sxbp_render_figure_to_pbm(NULL, NULL, NULL, NULL)
+        == SXBP_RESULT_FAIL_PRECONDITION
+    );
     // now test normal usage of the public API
-    const char* string = "SXBP";
+    const char* string = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
     size_t length = strlen(string);
     sxbp_buffer_t buffer = { .size = length, .bytes = NULL, };
     if (!sxbp_init_buffer(&buffer)) {
@@ -98,6 +102,18 @@ int main(void) {
         sxbp_render_figure_to_bitmap(&figure, &bitmap);
         printf("\n");
         sxbp_print_bitmap(&bitmap, stdout);
+        outcome = sxbp_render_figure(
+            &figure,
+            &buffer,
+            sxbp_render_figure_to_pbm,
+            NULL,
+            NULL
+        );
+        assert(outcome == SXBP_RESULT_OK);
+        FILE* output_file = fopen("sxbp-test.pbm", "wb");
+        assert(output_file != NULL);
+        outcome = sxbp_buffer_to_file(&buffer, output_file);
+        assert(output_file != NULL);
         sxbp_free_figure(&figure);
         sxbp_free_bitmap(&bitmap);
         return 0;

--- a/tests.c
+++ b/tests.c
@@ -30,12 +30,7 @@ extern "C"{
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 static void print_progress(const sxbp_figure_t* figure, void* context) {
-    printf("%" PRIu32 "\n", figure->lines_remaining);
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
-    sxbp_render_figure_to_bitmap(figure, &bitmap);
-    sxbp_print_bitmap(&bitmap, stdout);
-    // free the memory, be a good person!
-    sxbp_free_bitmap(&bitmap);
+    printf("%" PRIu32 "|", figure->lines_remaining);
     fflush(stdout);
 }
 // reënable all warnings
@@ -64,6 +59,10 @@ int main(void) {
         sxbp_render_figure_to_bitmap(NULL, NULL)
         == SXBP_RESULT_FAIL_PRECONDITION
     );
+    assert(
+        sxbp_render_figure(NULL, NULL, NULL, NULL, NULL)
+        == SXBP_RESULT_FAIL_PRECONDITION
+    );
     // now test normal usage of the public API
     const char* string = "SXBP";
     size_t length = strlen(string);
@@ -83,8 +82,12 @@ int main(void) {
         };
         sxbp_result_t outcome = sxbp_refine_figure(&figure, &options);
         assert(outcome == SXBP_RESULT_OK);
+        // test null renderer can be called
+        sxbp_render_figure(&figure, &buffer, sxbp_render_to_null, NULL, NULL);
         // render complete figure to bitmap
         sxbp_render_figure_to_bitmap(&figure, &bitmap);
+        printf("\n");
+        sxbp_print_bitmap(&bitmap, stdout);
         sxbp_free_figure(&figure);
         sxbp_free_bitmap(&bitmap);
         return 0;


### PR DESCRIPTION
Adds functionality (transferred from the older version of this project and split up into separate functions) for rendering a figure to PBM format image data.