### PR TITLE
Enable clang/GCC -Wconversion flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ os:
 compiler:
   - clang
   - gcc
-# different C Standard versions - test on C99 and C11
-env:
-  matrix:
-    - SXBP_C_STANDARD=99
-    - SXBP_C_STANDARD=11
 cache:
   - ccache
 addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,12 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_c_compiler_flag_if_supported("-Wstrict-prototypes")
     # enable warnings on missing prototypes of global functions
     enable_c_compiler_flag_if_supported("-Wmissing-prototypes")
-    # turn off spurious warnings from clang about missing field initialisers
-    enable_c_compiler_flag_if_supported("-Wno-missing-field-initializers")
+    # enable sign and type conversion warnings
+    enable_c_compiler_flag_if_supported("-Wconversion")
     # enable warnings about mistakes in Doxygen documentation
     enable_c_compiler_flag_if_supported("-Wdocumentation")
+    # turn off spurious warnings from clang about missing field initialisers
+    enable_c_compiler_flag_if_supported("-Wno-missing-field-initializers")
     # convert all warnings into errors
     enable_c_compiler_flag_if_supported("-Werror")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,12 @@ add_definitions(-DSXBP_VERSION_STRING=${SXBP_ESCAPED_VERSION_STRING})
 include(CheckCCompilerFlag)
 
 function(enable_c_compiler_flag_if_supported flag)
+    message(STATUS "[sxbp] Checking if compiler supports warning flag '${flag}'")
     string(FIND "${CMAKE_C_FLAGS}" "${flag}" flag_already_set)
     if(flag_already_set EQUAL -1)
         check_c_compiler_flag("${flag}" flag_supported)
         if(flag_supported)
-            message(STATUS "[sxbp] Enabling warning flag ${flag}")
+            message(STATUS "[sxbp] Enabling warning flag '${flag}'")
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}" PARENT_SCOPE)
         endif()
     endif()
@@ -87,6 +88,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_c_compiler_flag_if_supported("-Wmissing-prototypes")
     # enable sign and type conversion warnings
     enable_c_compiler_flag_if_supported("-Wconversion")
+    # enable warnings about C11 features not supported in C99
+    enable_c_compiler_flag_if_supported("-Wc99-c11-compat")
     # enable warnings about mistakes in Doxygen documentation
     enable_c_compiler_flag_if_supported("-Wdocumentation")
     # turn off spurious warnings from clang about missing field initialisers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     # enable warnings on missing prototypes of global functions
     enable_c_compiler_flag_if_supported("-Wmissing-prototypes")
     # enable sign and type conversion warnings
-    enable_c_compiler_flag_if_supported("-Wconversion")
+    enable_c_compiler_flag_if_supported("-Wsign-conversion")
     # enable warnings about C11 features not supported in C99
     enable_c_compiler_flag_if_supported("-Wc99-c11-compat")
     # enable warnings about mistakes in Doxygen documentation

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -55,7 +55,7 @@ static sxbp_direction_t sxbp_change_line_direction(
     sxbp_direction_t current,
     sxbp_rotation_t turn
 ) {
-    return (current + turn) % 4;
+    return (sxbp_direction_t)((current + (sxbp_direction_t)turn) % 4);
 }
 
 /*
@@ -72,13 +72,13 @@ static sxbp_length_t sxbp_next_length(
     assert(direction <= SXBP_LEFT);
     switch (direction % 4u) {
         case SXBP_UP:
-            return abs(bounds.y_max - location.y) + 1;
+            return (sxbp_length_t)labs(bounds.y_max - location.y) + 1;
         case SXBP_RIGHT:
-            return abs(bounds.x_max - location.x) + 1;
+            return (sxbp_length_t)labs(bounds.x_max - location.x) + 1;
         case SXBP_DOWN:
-            return abs(bounds.y_min - location.y) + 1;
+            return (sxbp_length_t)labs(bounds.y_min - location.y) + 1;
         case SXBP_LEFT:
-            return abs(bounds.x_min - location.x) + 1;
+            return (sxbp_length_t)labs(bounds.x_min - location.x) + 1;
         default:
             /*
              * NOTE: this case should never happen
@@ -158,7 +158,7 @@ sxbp_result_t sxbp_begin_figure(
          * the number of lines is the number of bits in the buffer
          * (byte count * 8) + 1 (for the extra starting line)
          */
-        figure->size = data->size * 8 + 1;
+        figure->size = (sxbp_figure_size_t)(data->size * 8 + 1);
         // use default options if `options` is `NULL`
         if (options == NULL) {
             options = &SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -55,7 +55,7 @@ static sxbp_direction_t sxbp_change_line_direction(
     sxbp_direction_t current,
     sxbp_rotation_t turn
 ) {
-    return (sxbp_direction_t)((current + (sxbp_direction_t)turn) % 4);
+    return (current + (sxbp_direction_t)turn) % 4;
 }
 
 /*
@@ -72,13 +72,13 @@ static sxbp_length_t sxbp_next_length(
     assert(direction <= SXBP_LEFT);
     switch (direction % 4u) {
         case SXBP_UP:
-            return (sxbp_length_t)labs(bounds.y_max - location.y) + 1;
+            return labs(bounds.y_max - location.y) + 1;
         case SXBP_RIGHT:
-            return (sxbp_length_t)labs(bounds.x_max - location.x) + 1;
+            return labs(bounds.x_max - location.x) + 1;
         case SXBP_DOWN:
-            return (sxbp_length_t)labs(bounds.y_min - location.y) + 1;
+            return labs(bounds.y_min - location.y) + 1;
         case SXBP_LEFT:
-            return (sxbp_length_t)labs(bounds.x_min - location.x) + 1;
+            return labs(bounds.x_min - location.x) + 1;
         default:
             /*
              * NOTE: this case should never happen
@@ -158,7 +158,7 @@ sxbp_result_t sxbp_begin_figure(
          * the number of lines is the number of bits in the buffer
          * (byte count * 8) + 1 (for the extra starting line)
          */
-        figure->size = (sxbp_figure_size_t)(data->size * 8 + 1);
+        figure->size = data->size * 8 + 1;
         // use default options if `options` is `NULL`
         if (options == NULL) {
             options = &SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -40,7 +40,8 @@ static bool sxbp_render_figure_to_bitmap_callback(
     void* callback_data
 ) {
     // cast void pointer to a pointer to our context structure
-    render_figure_to_bitmap_context* data = (render_figure_to_bitmap_context*)callback_data;
+    render_figure_to_bitmap_context* data =
+        (render_figure_to_bitmap_context*)callback_data;
     // skip the plotting of the second pixel
     if (data->first_pixel_complete && !data->second_pixel_complete) {
         // mark second pixel as complete
@@ -49,7 +50,9 @@ static bool sxbp_render_figure_to_bitmap_callback(
         // mark first pixel as complete if it isn't already
         data->first_pixel_complete = true;
         // plot the pixel, but flip the y coördinate
-        data->image->pixels[location.x][data->image->height - 1 - (uint32_t)location.y] = true;
+        data->image
+            ->pixels[location.x]
+            [data->image->height - 1 - (uint32_t)location.y] = true;
     }
     // return true --we always want to continue
     return true;

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -13,6 +13,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "sxbp.h"
 #include "sxbp_internal.h"
@@ -48,7 +49,7 @@ static bool sxbp_render_figure_to_bitmap_callback(
         // mark first pixel as complete if it isn't already
         data->first_pixel_complete = true;
         // plot the pixel, but flip the y coördinate
-        data->image->pixels[location.x][data->image->height - 1 - location.y] = true;
+        data->image->pixels[location.x][data->image->height - 1 - (uint32_t)location.y] = true;
     }
     // return true --we always want to continue
     return true;

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -256,7 +256,7 @@ static void sxbp_read_sxbp_data_line(
      * handle first byte on it's own as we only need least 6 bits of it
      * bit mask and shift 3 bytes to left
      */
-    line->length = (buffer->bytes[index] & 0x3f) << 24; // 0x3f = 0b00111111
+    line->length = (buffer->bytes[index] & 0x3fU) << 24; // 0x3f = 0b00111111
     // next byte
     index++;
     // handle remaining 3 bytes in loop

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -130,7 +130,7 @@ static void sxbp_write_sxbp_data_line(
 ) {
     size_t index = *start_index;
     // the leading 2 bits of the first byte are used for the direction
-    buffer->bytes[index] = (uint8_t)(line.direction << 6u);
+    buffer->bytes[index] = line.direction << 6u;
     // the next 6 bits of the first byte are used for the first 6 bits of length
     buffer->bytes[index] |= (line.length >> 24);
     // move on to the next byte
@@ -256,7 +256,7 @@ static void sxbp_read_sxbp_data_line(
      * handle first byte on it's own as we only need least 6 bits of it
      * bit mask and shift 3 bytes to left
      */
-    line->length = (sxbp_length_t)((buffer->bytes[index] & 0x3f) << 24); // 0x3f = 0b00111111
+    line->length = (buffer->bytes[index] & 0x3f) << 24; // 0x3f = 0b00111111
     // next byte
     index++;
     // handle remaining 3 bytes in loop

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -171,7 +171,8 @@ static uint16_t sxbp_load_uint16_t(
     size_t index = *start_index;
     // extract the value
     uint16_t value = (
-        (uint16_t)((uint16_t)buffer->bytes[index] << 8) + buffer->bytes[index + 1]
+        (uint16_t)((uint16_t)buffer->bytes[index] << 8) +
+        buffer->bytes[index + 1]
     );
     // increment index to point to next location
     *start_index += 2;

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -130,7 +130,7 @@ static void sxbp_write_sxbp_data_line(
 ) {
     size_t index = *start_index;
     // the leading 2 bits of the first byte are used for the direction
-    buffer->bytes[index] = (line.direction << 6);
+    buffer->bytes[index] = (uint8_t)(line.direction << 6u);
     // the next 6 bits of the first byte are used for the first 6 bits of length
     buffer->bytes[index] |= (line.length >> 24);
     // move on to the next byte
@@ -171,7 +171,7 @@ static uint16_t sxbp_load_uint16_t(
     size_t index = *start_index;
     // extract the value
     uint16_t value = (
-        ((uint16_t)buffer->bytes[index] << 8) + buffer->bytes[index + 1]
+        (uint16_t)((uint16_t)buffer->bytes[index] << 8) + buffer->bytes[index + 1]
     );
     // increment index to point to next location
     *start_index += 2;
@@ -195,7 +195,7 @@ static uint32_t sxbp_load_uint32_t(
     // extract the value
     uint32_t value = 0;
     for(uint8_t i = 0; i < 4; i++) {
-        value |= (buffer->bytes[index + i]) << (8 * (3 - i));
+        value |= (uint8_t)((buffer->bytes[index + i]) << (8 * (3 - i)));
     }
     // increment index to point to next location
     *start_index += 4;
@@ -255,7 +255,7 @@ static void sxbp_read_sxbp_data_line(
      * handle first byte on it's own as we only need least 6 bits of it
      * bit mask and shift 3 bytes to left
      */
-    line->length = (buffer->bytes[index] & 0x3f) << 24; // 0x3f = 0b00111111
+    line->length = (sxbp_length_t)((buffer->bytes[index] & 0x3f) << 24); // 0x3f = 0b00111111
     // next byte
     index++;
     // handle remaining 3 bytes in loop

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -130,7 +130,7 @@ static void sxbp_write_sxbp_data_line(
 ) {
     size_t index = *start_index;
     // the leading 2 bits of the first byte are used for the direction
-    buffer->bytes[index] = line.direction << 6u;
+    buffer->bytes[index] = line.direction << 6;
     // the next 6 bits of the first byte are used for the first 6 bits of length
     buffer->bytes[index] |= (line.length >> 24);
     // move on to the next byte

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -228,7 +228,7 @@ typedef enum sxbp_result_t {
     SXBP_RESULT_OK, /**< success */
     SXBP_RESULT_FAIL_MEMORY, /**< failure to allocate or reallocate memory */
     SXBP_RESULT_FAIL_PRECONDITION, /**< a preconditional check failed */
-    SXBP_RESULT_FAIL_FILE, /**< a file read/write operation failed */
+    SXBP_RESULT_FAIL_IO, /**< an input/output operation failed */
     SXBP_RESULT_FAIL_UNIMPLEMENTED, /**< requested action is not implemented */
     SXBP_RESULT_RESERVED_START, /**< reserved for future use */
     SXBP_RESULT_RESERVED_END = 255u, /**< reserved for future use */
@@ -356,7 +356,7 @@ sxbp_result_t sxbp_copy_buffer(
  * @param file_handle The file to read data from
  * @param[out] buffer The buffer to write data to
  * @returns `SXBP_RESULT_OK` on successfully copying the file contents
- * @returns `SXBP_RESULT_FAIL_MEMORY` or `SXBP_RESULT_FAIL_FILE` on failure to copy the file contents
+ * @returns `SXBP_RESULT_FAIL_MEMORY` or `SXBP_RESULT_FAIL_IO` on failure to copy the file contents
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `file_handle` or `buffer` is
  * `NULL`
  * @since v0.54.0
@@ -373,7 +373,7 @@ sxbp_result_t sxbp_buffer_from_file(
  * @param buffer The buffer to read data from
  * @param[out] file_handle The file to write data to
  * @returns `SXBP_RESULT_OK` on successfully writing the file
- * @returns `SXBP_RESULT_FAIL_FILE` on failure to write the file
+ * @returns `SXBP_RESULT_FAIL_IO` on failure to write the file
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `buffer` or `file_handle` is
  * `NULL`
  * @since v0.54.0

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -78,7 +78,7 @@ sxbp_bounds_t sxbp_get_bounds(const sxbp_figure_t* figure, size_t scale) {
         sxbp_move_location(
             &location,
             figure->lines[i].direction,
-            (sxbp_length_t)(figure->lines[i].length * scale)
+            figure->lines[i].length * scale
         );
         // update the bounds
         sxbp_update_bounds(location, &bounds);

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -57,8 +57,8 @@ void sxbp_move_location(
     sxbp_length_t length
 ) {
     sxbp_vector_t vector = SXBP_VECTOR_DIRECTIONS[direction];
-    location->x += vector.x * length;
-    location->y += vector.y * length;
+    location->x += vector.x * (sxbp_tuple_item_t)length;
+    location->y += vector.y * (sxbp_tuple_item_t)length;
 }
 
 void sxbp_move_location_along_line(
@@ -78,7 +78,7 @@ sxbp_bounds_t sxbp_get_bounds(const sxbp_figure_t* figure, size_t scale) {
         sxbp_move_location(
             &location,
             figure->lines[i].direction,
-            figure->lines[i].length * scale
+            (sxbp_length_t)(figure->lines[i].length * scale)
         );
         // update the bounds
         sxbp_update_bounds(location, &bounds);
@@ -141,8 +141,8 @@ sxbp_result_t sxbp_make_bitmap_for_bounds(
      * this makes sense because for example from 1 to 10 there are 10 values
      * and the difference of these is 9 so the number of values is 9+1 = 10
      */
-    bitmap->width = (bounds.x_max - bounds.x_min) + 1;
-    bitmap->height = (bounds.y_max - bounds.y_min) + 1;
+    bitmap->width = (uint32_t)((bounds.x_max - bounds.x_min) + 1);
+    bitmap->height = (uint32_t)((bounds.y_max - bounds.y_min) + 1);
     bitmap->pixels = NULL;
     // allocate memory for the bitmap and return the status of this operation
     return sxbp_init_bitmap(bitmap);

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -102,7 +102,7 @@ static size_t sxbp_get_file_size(FILE* file_handle) {
     // NOTE: This isn't portable due to lack of meaningful support of `SEEK_END`
     fseek(file_handle, 0, SEEK_END);
     // get size
-    size_t file_size = ftell(file_handle);
+    size_t file_size = (size_t)ftell(file_handle);
     // seek to start again
     fseek(file_handle, 0, SEEK_SET);
     return file_size;
@@ -139,7 +139,7 @@ sxbp_result_t sxbp_buffer_from_file(
             // we didn't read the same number of bytes as the file's size
             sxbp_free_buffer(buffer);
             // return a file error
-            return SXBP_RESULT_FAIL_FILE;
+            return SXBP_RESULT_FAIL_IO;
         } else {
             // we read the buffer successfully, so return success
             return SXBP_RESULT_OK;
@@ -162,7 +162,7 @@ sxbp_result_t sxbp_buffer_to_file(
         file_handle
     );
     // return success/failure if the correct number of bytes were written
-    return bytes_written == buffer->size ? SXBP_RESULT_OK : SXBP_RESULT_FAIL_FILE;
+    return bytes_written == buffer->size ? SXBP_RESULT_OK : SXBP_RESULT_FAIL_IO;
 }
 
 sxbp_figure_t sxbp_blank_figure(void) {


### PR DESCRIPTION
This flag enables warnings for implicit sign and data type conversion (and of course as with all warnings receiving any of these will fail the build, as I want them to!).
The solution for code which causes these warnings to appear is to add an explicit cast