### PR TITLE
Re-implement grow from start refinement algorithm

### DIFF
--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -39,6 +39,7 @@ static sxbp_line_t sxbp_make_line(
     sxbp_direction_t direction,
     sxbp_length_t length
 ) {
+    // TODO: add line index!
     return (sxbp_line_t){ .direction = direction, .length = length, };
 }
 
@@ -101,6 +102,7 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
     // the first line is always an up line - this is for orientation purposes
     sxbp_direction_t facing = SXBP_UP;
     // add first line to the figure
+    // TODO: add line index!
     figure->lines[0] = sxbp_make_line(facing, 1);
     // update the location
     sxbp_move_location_along_line(&location, figure->lines[0]);
@@ -130,6 +132,7 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
             // calculate what length this line should be
             sxbp_length_t length = sxbp_next_length(location, facing, bounds);
             // make line
+            // TODO: add line index!
             sxbp_line_t line = sxbp_make_line(facing, length);
             // add line to figure
             figure->lines[index] = line;

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -36,11 +36,15 @@ typedef enum sxbp_rotation_t {
 
 // private, builds a line from a direction and length
 static sxbp_line_t sxbp_make_line(
+    sxbp_figure_size_t index,
     sxbp_direction_t direction,
     sxbp_length_t length
 ) {
-    // TODO: add line index!
-    return (sxbp_line_t){ .direction = direction, .length = length, };
+    return (sxbp_line_t){
+        .id = index,
+        .direction = direction,
+        .length = length,
+    };
 }
 
 // private, converts a binary bit into a rotational direction
@@ -102,8 +106,7 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
     // the first line is always an up line - this is for orientation purposes
     sxbp_direction_t facing = SXBP_UP;
     // add first line to the figure
-    // TODO: add line index!
-    figure->lines[0] = sxbp_make_line(facing, 1);
+    figure->lines[0] = sxbp_make_line(0u, facing, 1);
     // update the location
     sxbp_move_location_along_line(&location, figure->lines[0]);
     // update the bounds
@@ -132,8 +135,7 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
             // calculate what length this line should be
             sxbp_length_t length = sxbp_next_length(location, facing, bounds);
             // make line
-            // TODO: add line index!
-            sxbp_line_t line = sxbp_make_line(facing, length);
+            sxbp_line_t line = sxbp_make_line(index, facing, length);
             // add line to figure
             figure->lines[index] = line;
             // update location and bounds

--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -39,6 +39,8 @@ sxbp_result_t sxbp_refine_figure(
     }
     // now run the appropriate refinement function for all implemented methods
     switch (method) {
+        case SXBP_REFINE_METHOD_GROW_FROM_START:
+            return sxbp_refine_figure_grow_from_start(figure, options);
         case SXBP_REFINE_METHOD_SHRINK_FROM_END:
             return sxbp_refine_figure_shrink_from_end(figure, options);
         default:

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -28,6 +28,26 @@ extern "C" {
 // disable GCC warning about the unused parameter, as this is currently a stub
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+/*
+ * Algorithm:
+ *
+ * - FOR all lines, counting forwards:
+ *     - SetLineLength(CurrentLine, 1)
+ *
+ * - SetLineLength(line, length)
+ *     - Try and SET 'line' length to 'length'
+ *     - IF this causes a collision:
+ *         - NOTE the line that it collided with (CollidedLine)
+ *         - SetLineLength(
+ *               PreviousLine, EvadeDistance(CurrentLine, CollidedLine)
+ *           )
+ *
+ * - EvadeDistance(PreviousLine, CurrentLine, CollidedLine)
+ *     - COMPARE PreviousLine, CurrentLine and CollidedLine lengths, directions
+ *       and positions to work out what length PreviousLine should be in order
+ *       for CurrentLine to not collide with CollidedLine
+ *     - RETURN new distance for PreviousLine
+ */
 sxbp_result_t sxbp_refine_figure_grow_from_start(
     sxbp_figure_t* figure,
     const sxbp_refine_figure_options_t* options

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -52,8 +52,22 @@ sxbp_result_t sxbp_refine_figure_grow_from_start(
     sxbp_figure_t* figure,
     const sxbp_refine_figure_options_t* options
 ) {
-    // FIXME: This function is currently unimplemented!
-    return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+    // variable to store any errors in
+    // sxbp_result_t status = SXBP_RESULT_UNKNOWN;
+    // try and set the length of each line in the figure (ascending) to 1
+    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
+        // TODO: this line will be moved out into a separate function
+        figure->lines[i].length = 1;
+        // set which how many lines we have left to solve
+        figure->lines_remaining = figure->size - 1 - i;
+        // TODO: refactor the following code into sxbp_internal:
+        // call the progress callback if it's been given
+        if (options != NULL && options->progress_callback != NULL) {
+            options->progress_callback(figure, options->callback_context);
+        }
+    }
+    // signal to caller that the call succeeded
+    return SXBP_RESULT_OK;
 }
 // reënable all warnings
 #pragma GCC diagnostic pop

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -214,6 +214,11 @@ static bool sxbp_suggest_previous_length_callback(
     // cast void pointer to a pointer to our context structure
     suggest_previous_length_context* callback_data =
         (suggest_previous_length_context*)data;
+    // FIXME: This function is currently wrong:
+    // Because of the way lines are plotted, all lines apart from line 0 have
+    // their first coördinate marked as belonging to the previous line
+    // This means that their origin coördinates actually are the ones before!
+
     // lastly, update the current_location attribute to the one we've just seen
     callback_data->current_location = location;
     if (
@@ -333,6 +338,8 @@ static sxbp_length_t sxbp_suggest_previous_length(
             previous, collider, data.previous_origin, data.collider_origin
         );
         // TODO: replace with result of sxbp_resolve_collision() above
+        // FIXME: This can't be done until sxbp_suggest_previous_length_callback
+        // is fixed properly
         return previous.length + 1;
     }
 }

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -143,7 +143,6 @@ static bool sxbp_figure_collides_with_callback(
     if (callback_data->map->cells[location.x][location.y] != NULL) {
         // the thing we collided with is the pointer at this location, store it!
         *callback_data->collider = callback_data->map->cells[location.x][location.y];
-        printf("Collider is #%u\n", callback_data->map->cells[location.x][location.y]->id);
         // halt walking early by returning false
         return false;
     } else {
@@ -338,8 +337,6 @@ static sxbp_length_t sxbp_suggest_previous_length(
     }
 }
 
-static size_t RECURSION_COUNT = 0;
-
 /*
  * private, attempts to change the length of the line at the given line_index to
  * the requested line length.
@@ -349,16 +346,6 @@ static sxbp_result_t sxbp_set_line_length(
     sxbp_figure_size_t line_index,
     sxbp_length_t line_length
 ) {
-    RECURSION_COUNT++;
-    // printf("RECURSION DEPTH: %zu\n", RECURSION_COUNT);
-    // printf("line_index:%u, line_length:%u\n", line_index, line_length);
-    // XXX: debugging
-    sxbp_bitmap_t bitmap = {0};
-    printf("Try line #%u\n", line_index);
-    // render incomplete figure to bitmap
-    sxbp_render_figure_to_bitmap(figure, &bitmap);
-    printf("\n");
-    sxbp_print_bitmap(&bitmap, stdout);
     // variable to store any errors in
     sxbp_result_t status = SXBP_RESULT_UNKNOWN;
     // try and set the line's length to that requested
@@ -375,9 +362,6 @@ static sxbp_result_t sxbp_set_line_length(
     } else {
         // while there is a collision (collider is not NULL)
         while (collider != NULL) {
-            sxbp_render_figure_to_bitmap(figure, &bitmap);
-            printf("\n");
-            sxbp_print_bitmap(&bitmap, stdout);
             // // set the original line at line index's length back to 0
             figure->lines[line_index].length = 0;
             // work out what length to extend the previous line to
@@ -386,7 +370,6 @@ static sxbp_result_t sxbp_set_line_length(
             );
             // call self recursively, to resize the previous line to new length
             // TODO: handle errors!
-            printf("RETRY PREVIOUS LINE!\n");
             assert(
                 sxbp_success(
                     sxbp_set_line_length(
@@ -412,12 +395,6 @@ static sxbp_result_t sxbp_set_line_length(
                 return status;
             }
         }
-        RECURSION_COUNT--;
-        // render complete figure to bitmap
-        sxbp_render_figure_to_bitmap(figure, &bitmap);
-        printf("\n");
-        sxbp_print_bitmap(&bitmap, stdout);
-        printf("Finished line #%u\n", line_index);
         // signal to caller that the call succeeded
         return SXBP_RESULT_OK;
     }

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -1,0 +1,44 @@
+/*
+ * This source file forms part of sxbp, a library which generates experimental
+ * 2D spiral-like shapes based on input binary data.
+ *
+ * This compilation unit provides the definition of
+ * `sxbp_refine_figure_grow_from_start`, a public function providing a specific
+ * algorithm for refining a figure by attemptin to shrink all the lines from
+ * their safe 'default' lengths (as plotted by `sxbp_begin_figure`) to the
+ * shortest length possible, starting from the end and working backwards.
+ *
+ * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "sxbp.h"
+#include "sxbp_internal.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// disable GCC warning about the unused parameter, as this is currently a stub
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+sxbp_result_t sxbp_refine_figure_grow_from_start(
+    sxbp_figure_t* figure,
+    const sxbp_refine_figure_options_t* options
+) {
+    // FIXME: This function is currently unimplemented!
+    return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+}
+// reënable all warnings
+#pragma GCC diagnostic pop
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -139,8 +139,6 @@ static bool sxbp_figure_collides_with_callback(
     // cast void pointer to a pointer to our context structure
     figure_collides_with_context* callback_data =
         (figure_collides_with_context*)data;
-    // is this the last line? if so we need to tell walk() to finish early
-    bool last_line = (line->id == callback_data->max_line);
     /*
      * if a pixel would be plotted at a location that isn't NULL, then stop and
      * set collider to point to the location that would have been plotted to
@@ -158,7 +156,7 @@ static bool sxbp_figure_collides_with_callback(
          */
         callback_data->map->cells[location.x][location.y] = line;
         // only continue if it's not the last line
-        return !last_line;
+        return !(line->id == callback_data->max_line);
     }
 }
 
@@ -230,7 +228,6 @@ static sxbp_result_t sxbp_set_line_length(
     } else {
         // if collider is not NULL, then there's been a collision
         if (collider != NULL) {
-            printf("!\n");
             // collision!
             //   TODO: work out what length to extend the previous line to
             //   ...

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -4,9 +4,8 @@
  *
  * This compilation unit provides the definition of
  * `sxbp_refine_figure_grow_from_start`, a public function providing a specific
- * algorithm for refining a figure by attemptin to shrink all the lines from
- * their safe 'default' lengths (as plotted by `sxbp_begin_figure`) to the
- * shortest length possible, starting from the end and working backwards.
+ * algorithm for refining a figure by attempting to grow the lines before those
+ * that collide until the collision stops, doing this recursively as required.
  *
  * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
  *

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -25,9 +25,6 @@
 extern "C" {
 #endif
 
-// disable GCC warning about the unused parameter, as this is currently a stub
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 /*
  * Algorithm:
  *
@@ -69,8 +66,6 @@ sxbp_result_t sxbp_refine_figure_grow_from_start(
     // signal to caller that the call succeeded
     return SXBP_RESULT_OK;
 }
-// reënable all warnings
-#pragma GCC diagnostic pop
 
 #ifdef __cplusplus
 } // extern "C"

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -45,6 +45,22 @@ extern "C" {
  *       for CurrentLine to not collide with CollidedLine
  *     - RETURN new distance for PreviousLine
  */
+
+/*
+ * private, attempts to change the length of the line at the given line_index to
+ * the requested line length.
+ */
+static sxbp_result_t sxbp_set_line_length(
+    sxbp_figure_t* figure,
+    sxbp_figure_size_t line_index,
+    sxbp_length_t line_length
+) {
+    // TODO: Check if this causes collision and call self recursively if it does
+    figure->lines[line_index].length = line_length;
+    // signal to caller that the call succeeded
+    return SXBP_RESULT_OK;
+}
+
 sxbp_result_t sxbp_refine_figure_grow_from_start(
     sxbp_figure_t* figure,
     const sxbp_refine_figure_options_t* options
@@ -53,8 +69,8 @@ sxbp_result_t sxbp_refine_figure_grow_from_start(
     // sxbp_result_t status = SXBP_RESULT_UNKNOWN;
     // try and set the length of each line in the figure (ascending) to 1
     for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
-        // TODO: this line will be moved out into a separate function
-        figure->lines[i].length = 1;
+        // try and set the line length to 1 using a helper function
+        sxbp_set_line_length(figure, i, 1); // TODO: Handle error!
         // set which how many lines we have left to solve
         figure->lines_remaining = figure->size - 1 - i;
         // TODO: refactor the following code into sxbp_internal:

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -129,6 +129,7 @@ static sxbp_result_t sxbp_init_line_map_from_bounds(
 
 // private, callback function for sxbp_figure_collides_with()
 static bool sxbp_figure_collides_with_callback(
+    sxbp_line_t* line,
     sxbp_co_ord_t location,
     void* data
 ) {
@@ -150,10 +151,9 @@ static bool sxbp_figure_collides_with_callback(
          * otherwise, we haven't collided yet so mark the cell with a pointer to
          * the current line
          */
-        // XXX: Whoops! sxbp_walk_figure() doesn't tell us which line we're on!
-        // TODO: change sxbp_walk_figure() to give us the line pointer too
+        callback_data->map->cells[location.x][location.y] = line;
+        return true;
     }
-    return true;
 }
 
 // XXX: Stub functions don't need warnings about unused parameters!

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -135,24 +135,30 @@ static bool sxbp_figure_collides_with_callback(
     // cast void pointer to a pointer to our context structure
     figure_collides_with_context* callback_data =
         (figure_collides_with_context*)data;
-    /*
-     * if a pixel would be plotted at a location that isn't NULL, then stop and
-     * set collider to point to the location that would have been plotted to
-     * --this is the line that would be collided with
-     */
-    if (callback_data->map->cells[location.x][location.y] != NULL) {
-        // the thing we collided with is the pointer at this location, store it!
-        *callback_data->collider = callback_data->map->cells[location.x][location.y];
-        // halt walking early by returning false
+    // if the line's ID is greater than the max line we want, we can quit NOW
+    if (line->id > callback_data->max_line) {
         return false;
     } else {
         /*
-         * otherwise, we haven't collided yet so mark the cell with a pointer to
-         * the current line
+         * if a pixel would be plotted at a location that isn't NULL, then stop
+         * and set collider to point to the location that would have been
+         * plotted to --this is the line that would be collided with
          */
-        callback_data->map->cells[location.x][location.y] = line;
-        // only continue if it's not the last line
-        return !(line->id > callback_data->max_line);
+        if (callback_data->map->cells[location.x][location.y] != NULL) {
+            // the line we collided with is the pointer in this cell, store it!
+            *callback_data->collider =
+                callback_data->map->cells[location.x][location.y];
+            // halt walking early by returning false
+            return false;
+        } else {
+            /*
+             * otherwise, we haven't collided yet so mark the cell with a
+             * pointer to the current line
+             */
+            callback_data->map->cells[location.x][location.y] = line;
+            // tell sxbp_walk_figure() that we want to continue!
+            return true;
+        }
     }
 }
 

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -256,6 +256,15 @@ static sxbp_length_t sxbp_resolve_collision(
     // calculate collider end coördinates
     sxbp_co_ord_t collider_end = collider_origin;
     sxbp_move_location_along_line(&collider_end, collider);
+    // XXX: This soup of if and else-if blocks is copied direct from the
+    // original implementation. It cannot be verified to work correctly until
+    // sxbp_suggest_previous_length_callback is fixed.
+    // TODO: Once verified that this logic is correct, replace with a lookup
+    // table approach, using the SXBP direction constants as indices
+    // (lookup table will be a 2D array of the expressions that change)
+    // WARN: if this approach is used, a check should first be made to check and
+    // rule out the combinations of directions not featured in the table (any
+    // non-parallel combos, which cannot be optimised in this manner)
     if((previous.direction == SXBP_UP) && (collider.direction == SXBP_UP)) {
         return (collider_origin.y - previous_origin.y) + collider.length + 1;
     } else if((previous.direction == SXBP_UP) && (collider.direction == SXBP_DOWN)) {

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -56,10 +56,12 @@ static bool sxbp_free_line_map(line_map* map) {
             // but first check each column of the col inside cells too
             if (map->cells[col] != NULL) {
                 free(map->cells[col]);
+                map->cells[col] = NULL;
             }
         }
         // finally, deallocate the row
         free(map->cells);
+        map->cells = NULL;
         return true;
     } else {
         // nothing to deallocate!
@@ -160,9 +162,6 @@ static bool sxbp_figure_collides_with_callback(
     }
 }
 
-// XXX: Stub functions don't need warnings about unused parameters!
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 /*
  * private, given an sxbp figure, the most recently plotted line index and a
  * pointer to a pointer to a line, checks if the full line of the given figure
@@ -205,8 +204,6 @@ static sxbp_result_t sxbp_figure_collides_with(
         return SXBP_RESULT_OK;
     }
 }
-// reënable all warnings
-#pragma GCC diagnostic pop
 
 /*
  * private, attempts to change the length of the line at the given line_index to

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -266,24 +266,24 @@ static sxbp_length_t sxbp_resolve_collision(
     // rule out the combinations of directions not featured in the table (any
     // non-parallel combos, which cannot be optimised in this manner)
     if((previous.direction == SXBP_UP) && (collider.direction == SXBP_UP)) {
-        return (sxbp_figure_dimension_t)((collider_origin.y - previous_origin.y) + collider.length + 1);
+        return (sxbp_length_t)((collider_origin.y - previous_origin.y) + collider.length + 1);
     } else if((previous.direction == SXBP_UP) && (collider.direction == SXBP_DOWN)) {
-        return (sxbp_figure_dimension_t)((collider_end.y - previous_origin.y) + collider.length + 1);
+        return (sxbp_length_t)((collider_end.y - previous_origin.y) + collider.length + 1);
     } else if((previous.direction == SXBP_RIGHT) && (collider.direction == SXBP_RIGHT)) {
-        return (sxbp_figure_dimension_t)((collider_origin.x - previous_origin.x) + collider.length + 1);
+        return (sxbp_length_t)((collider_origin.x - previous_origin.x) + collider.length + 1);
     } else if((previous.direction == SXBP_RIGHT) && (collider.direction == SXBP_LEFT)) {
-        return (sxbp_figure_dimension_t)((collider_end.x - previous_origin.x) + collider.length + 1);
+        return (sxbp_length_t)((collider_end.x - previous_origin.x) + collider.length + 1);
     } else if((previous.direction == SXBP_DOWN) && (collider.direction == SXBP_UP)) {
-        return (sxbp_figure_dimension_t)((previous_origin.y - collider_end.y) + collider.length + 1);
+        return (sxbp_length_t)((previous_origin.y - collider_end.y) + collider.length + 1);
     } else if((previous.direction == SXBP_DOWN) && (collider.direction == SXBP_DOWN)) {
-        return (sxbp_figure_dimension_t)((previous_origin.y - collider_origin.y) + collider.length + 1);
+        return (sxbp_length_t)((previous_origin.y - collider_origin.y) + collider.length + 1);
     } else if((previous.direction == SXBP_LEFT) && (collider.direction == SXBP_RIGHT)) {
-        return (sxbp_figure_dimension_t)((previous_origin.x - collider_end.x) + collider.length + 1);
+        return (sxbp_length_t)((previous_origin.x - collider_end.x) + collider.length + 1);
     } else if((previous.direction == SXBP_LEFT) && (collider.direction == SXBP_LEFT)) {
-        return (sxbp_figure_dimension_t)((previous_origin.x - collider_origin.x) + collider.length + 1);
+        return (sxbp_length_t)((previous_origin.x - collider_origin.x) + collider.length + 1);
     } else {
         // this is the catch-all case, where no way to optimise was found
-        return previous.length + 1;
+        return previous.length + 1U;
     }
 }
 
@@ -325,7 +325,7 @@ static sxbp_length_t sxbp_suggest_previous_length(
     // );
     // // if the two lines are not parallel, just extend by 1 and return early
     if((previous.direction % 2u) != (collider.direction % 2u)) {
-        return previous.length + 1;
+        return previous.length + 1U;
     } else {
         /*
          * otherwise, use our callback function with sxbp_walk_figure() to get
@@ -349,7 +349,7 @@ static sxbp_length_t sxbp_suggest_previous_length(
         // TODO: replace with result of sxbp_resolve_collision() above
         // FIXME: This can't be done until sxbp_suggest_previous_length_callback
         // is fixed properly
-        return previous.length + 1;
+        return previous.length + 1U;
     }
 }
 

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -198,18 +198,6 @@ static sxbp_result_t sxbp_figure_collides_with(
         sxbp_walk_figure(
             figure, 1, sxbp_figure_collides_with_callback, (void*)&data
         );
-        // XXX: debugging, print the line map
-        for (uint32_t row = 0; row < map.height; row++) {
-            for (uint32_t col = 0; col < map.width; col++) {
-                if (map.cells[col][map.height - 1 - row] != NULL) {
-                    printf("%x", map.cells[col][map.height - 1 - row]->id);
-                } else {
-                    printf("░");
-                }
-            }
-            printf("\n");
-        }
-        printf("\n");
         // free the line map
         sxbp_free_line_map(&map);
         // signal to caller that the call succeeded
@@ -340,12 +328,6 @@ static sxbp_length_t sxbp_suggest_previous_length(
         sxbp_walk_figure(
             figure, 1, sxbp_suggest_previous_length_callback, (void*)&data
         );
-        // XXX: Debugging code
-        // printf(
-        //     "(%u, %u) and (%u, %u)\n",
-        //     data.previous_origin.x, data.previous_origin.y,
-        //     data.collider_origin.x, data.collider_origin.y
-        // );
         // use collision resolution rules to calculate the length to resize to
         sxbp_resolve_collision(
             previous, collider, data.previous_origin, data.collider_origin
@@ -377,10 +359,6 @@ static sxbp_result_t sxbp_set_line_length(
     while (true) {
         // set the target line to the target length
         figure->lines[target_index].length = target_length;
-        // XXX: debugging, render figure
-        sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
-        sxbp_render_figure_to_bitmap(figure, &bitmap);
-        sxbp_print_bitmap(&bitmap, stdout);
         // check if the figure now collides, and if so, with which other line?
         sxbp_line_t* collider = NULL;
         if (
@@ -400,8 +378,6 @@ static sxbp_result_t sxbp_set_line_length(
                  * alternative size to set the *previous* line to to try and
                  * resolve it
                  */
-                // XXX: debugging, reset the latest line to zero
-                figure->lines[target_index].length = 0;
                 // change target length so next iteration uses this suggestion
                 target_length = sxbp_suggest_previous_length(
                     figure, target_index, collider->id
@@ -453,10 +429,6 @@ sxbp_result_t sxbp_refine_figure_grow_from_start(
     sxbp_figure_t* figure,
     const sxbp_refine_figure_options_t* options
 ) {
-    // XXX: debugging
-    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
-        figure->lines[i].length = 0;
-    }
     // variable to store any errors in
     // sxbp_result_t status = SXBP_RESULT_UNKNOWN;
     // try and set the length of each line in the figure (ascending) to 1

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -46,6 +46,26 @@ extern "C" {
  *     - RETURN new distance for PreviousLine
  */
 
+// XXX: Stub functions don't need warnings about unused parameters!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+/*
+ * private, given an sxbp figure, the most recently plotted line index and a
+ * pointer to a pointer to a line, checks if the full line of the given figure
+ * as plotted up to the line index collides with itself. If it does, collider
+ * will be set to point to the line which it collides with.
+ */
+static sxbp_result_t sxbp_figure_collides_with(
+    const sxbp_figure_t* figure,
+    sxbp_figure_size_t line_index,
+    sxbp_line_t** collider
+) {
+    // signal to caller that the call succeeded
+    return SXBP_RESULT_OK;
+}
+// reënable all warnings
+#pragma GCC diagnostic pop
+
 /*
  * private, attempts to change the length of the line at the given line_index to
  * the requested line length.
@@ -55,8 +75,20 @@ static sxbp_result_t sxbp_set_line_length(
     sxbp_figure_size_t line_index,
     sxbp_length_t line_length
 ) {
-    // TODO: Check if this causes collision and call self recursively if it does
+    // try and set the line's length to that requested
     figure->lines[line_index].length = line_length;
+    // check if the figure now collides, and if so, with which other line?
+    sxbp_line_t* collider = NULL;
+    // TODO: Handle error!
+    sxbp_figure_collides_with(figure, line_index, &collider);
+    // IF COLLIDES:
+    //   TODO: work out what length to extend the previous line to
+    //   ...
+    //   TODO: call self recursively, to resize the previous line to new length
+    //   ...
+    //   TODO: set the original line at line index's length back to 1
+    //   NOTE: or do we set it to the originally requested length?
+    //   ...
     // signal to caller that the call succeeded
     return SXBP_RESULT_OK;
 }

--- a/sxbp/refine_figure_grow_from_start.c
+++ b/sxbp/refine_figure_grow_from_start.c
@@ -32,9 +32,9 @@ extern "C" {
  */
 typedef struct line_map {
     // the width of the line_map (same data type as bitmap width)
-    uint32_t width;
+    sxbp_figure_dimension_t width;
     // the height of the line_map (same data type as bitmap height)
-    uint32_t height;
+    sxbp_figure_dimension_t height;
     // dynamically allocated 2D array of pointers to lines
     sxbp_line_t*** cells;
 } line_map;
@@ -69,7 +69,7 @@ typedef struct suggest_previous_length_context {
 static bool sxbp_free_line_map(line_map* map) {
     // if map->cells is not null, then it needs to be deallocated
     if (map->cells != NULL) {
-        for (uint32_t col = 0; col < map->width; col++) {
+        for (sxbp_figure_dimension_t col = 0; col < map->width; col++) {
             // but first check each column of the col inside cells too
             if (map->cells[col] != NULL) {
                 free(map->cells[col]);
@@ -101,8 +101,8 @@ static sxbp_result_t sxbp_init_line_map_from_bounds(
      * this makes sense because for example from 1 to 10 there are 10 values
      * and the difference of these is 9 so the number of values is 9+1 = 10
      */
-    map->width = (bounds.x_max - bounds.x_min) + 1;
-    map->height = (bounds.y_max - bounds.y_min) + 1;
+    map->width = (sxbp_figure_dimension_t)(bounds.x_max - bounds.x_min) + 1;
+    map->height = (sxbp_figure_dimension_t)(bounds.y_max - bounds.y_min) + 1;
     // allocate dynamic memory for the row
     map->cells = calloc(map->width, sizeof(sxbp_line_t**));
     // catch allocation error and exit early
@@ -110,7 +110,7 @@ static sxbp_result_t sxbp_init_line_map_from_bounds(
         return SXBP_RESULT_FAIL_MEMORY;
     } else {
         // now allocate memory for the columns of the row
-        for (uint32_t col = 0; col < map->width; col++) {
+        for (sxbp_figure_dimension_t col = 0; col < map->width; col++) {
             map->cells[col] = calloc(map->height, sizeof(sxbp_line_t*));
             // catch allocation error, free and exit early
             if (map->cells[col] == NULL) {
@@ -118,7 +118,7 @@ static sxbp_result_t sxbp_init_line_map_from_bounds(
                 return SXBP_RESULT_FAIL_MEMORY;
             }
             // pedantic, set all cells within the column explicitly to NULL
-            for (uint32_t row = 0; row < map->height; row++) {
+            for (sxbp_figure_dimension_t row = 0; row < map->height; row++) {
                 map->cells[col][row] = NULL;
             }
         }
@@ -266,21 +266,21 @@ static sxbp_length_t sxbp_resolve_collision(
     // rule out the combinations of directions not featured in the table (any
     // non-parallel combos, which cannot be optimised in this manner)
     if((previous.direction == SXBP_UP) && (collider.direction == SXBP_UP)) {
-        return (collider_origin.y - previous_origin.y) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((collider_origin.y - previous_origin.y) + collider.length + 1);
     } else if((previous.direction == SXBP_UP) && (collider.direction == SXBP_DOWN)) {
-        return (collider_end.y - previous_origin.y) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((collider_end.y - previous_origin.y) + collider.length + 1);
     } else if((previous.direction == SXBP_RIGHT) && (collider.direction == SXBP_RIGHT)) {
-        return (collider_origin.x - previous_origin.x) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((collider_origin.x - previous_origin.x) + collider.length + 1);
     } else if((previous.direction == SXBP_RIGHT) && (collider.direction == SXBP_LEFT)) {
-        return (collider_end.x - previous_origin.x) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((collider_end.x - previous_origin.x) + collider.length + 1);
     } else if((previous.direction == SXBP_DOWN) && (collider.direction == SXBP_UP)) {
-        return (previous_origin.y - collider_end.y) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((previous_origin.y - collider_end.y) + collider.length + 1);
     } else if((previous.direction == SXBP_DOWN) && (collider.direction == SXBP_DOWN)) {
-        return (previous_origin.y - collider_origin.y) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((previous_origin.y - collider_origin.y) + collider.length + 1);
     } else if((previous.direction == SXBP_LEFT) && (collider.direction == SXBP_RIGHT)) {
-        return (previous_origin.x - collider_end.x) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((previous_origin.x - collider_end.x) + collider.length + 1);
     } else if((previous.direction == SXBP_LEFT) && (collider.direction == SXBP_LEFT)) {
-        return (previous_origin.x - collider_origin.x) + collider.length + 1;
+        return (sxbp_figure_dimension_t)((previous_origin.x - collider_origin.x) + collider.length + 1);
     } else {
         // this is the catch-all case, where no way to optimise was found
         return previous.length + 1;

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -32,8 +32,18 @@ typedef struct figure_collides_context {
     bool* collided;
 } figure_collides_context;
 
+/*
+ * disable GCC warning about the unused parameter, as this is a callback it must
+ * include all arguments specified by the caller, even if not used
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 // private, callback function for sxbp_figure_collides()
-static bool sxbp_figure_collides_callback(sxbp_co_ord_t location, void* data) {
+static bool sxbp_figure_collides_callback(
+    sxbp_line_t* line,
+    sxbp_co_ord_t location,
+    void* data
+) {
     // cast void pointer to a pointer to our context structure
     figure_collides_context* callback_data = (figure_collides_context*)data;
     // check if there's already a pixel here
@@ -49,6 +59,8 @@ static bool sxbp_figure_collides_callback(sxbp_co_ord_t location, void* data) {
         return false;
     }
 }
+// reënable all warnings
+#pragma GCC diagnostic pop
 
 // private, sets collided to true if the figure's line collides with itself
 static sxbp_result_t sxbp_figure_collides(

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -164,6 +164,7 @@ sxbp_result_t sxbp_refine_figure_shrink_from_end(
              * NOTE: this value is -1 because line 0 never needs solving
              */
             figure->lines_remaining = i - 1;
+            // TODO: refactor the following code into sxbp_internal:
             // call the progress callback if it's been given
             if (options != NULL && options->progress_callback != NULL) {
                 options->progress_callback(figure, options->callback_context);

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -4,7 +4,7 @@
  *
  * This compilation unit provides the definition of
  * `sxbp_refine_figure_shrink_from_end`, a public function providing a specific
- * algorithm for refining a figure by attemptin to shrink all the lines from
+ * algorithm for refining a figure by attempting to shrink all the lines from
  * their safe 'default' lengths (as plotted by `sxbp_begin_figure`) to the
  * shortest length possible, starting from the end and working backwards.
  *

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -34,8 +34,15 @@ typedef struct render_figure_to_bitmap_context {
     bool second_pixel_complete; // whether the second pixel has been plotted yet
 } render_figure_to_bitmap_context;
 
+/*
+ * disable GCC warning about the unused parameter, as this is a callback it must
+ * include all arguments specified by the caller, even if not used
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 // private, callback function for sxbp_render_figure_to_bitmap()
 static bool sxbp_render_figure_to_bitmap_callback(
+    sxbp_line_t* line,
     sxbp_co_ord_t location,
     void* callback_data
 ) {
@@ -57,6 +64,8 @@ static bool sxbp_render_figure_to_bitmap_callback(
     // return true --we always want to continue
     return true;
 }
+// reënable all warnings
+#pragma GCC diagnostic pop
 
 sxbp_result_t sxbp_render_figure_to_bitmap(
     const sxbp_figure_t* figure,

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -170,8 +170,15 @@ static sxbp_result_t sxbp_write_svg_body_origin_dot(
     return SXBP_RESULT_OK;
 }
 
+/*
+ * disable GCC warning about the unused parameter, as this is a callback it must
+ * include all arguments specified by the caller, even if not used
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 // private, callback function for sxbp_write_svg_body_figure_line()
 static bool sxbp_render_figure_to_bitmap_callback(
+    sxbp_line_t* line,
     sxbp_co_ord_t location,
     void* callback_data
 ) {
@@ -241,6 +248,8 @@ static bool sxbp_render_figure_to_bitmap_callback(
     data->current_point++;
     return true;
 }
+// reënable all warnings
+#pragma GCC diagnostic pop
 
 /*
  * private, given a figure and a buffer, writes out the SVG code for the

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -89,12 +89,17 @@ typedef uint32_t sxbp_figure_size_t;
 
 /**
  * @brief Represents one line segment in the spiral structure.
- * @details This includes the direction of the line and it's length
+ * @details This includes the ID, direction of the line and it's length
  * (initially set to 0).
- * @note The whole struct uses bitfields to occupy 32 bits of memory.
+ * @note The members `direction` and `length` use bitfields to occupy 32 bits of
+ * memory between them.
  * @since v0.27.0
  */
 typedef struct sxbp_line_t {
+    /**
+     * @brief the zero-indexed ID of this line, measured from the spiral origin
+     */
+    sxbp_figure_size_t id;
     /** @brief uses 2 bits as there's only 4 directions */
     sxbp_direction_t direction : 2;
     /** @brief uses 30 bits for the length, this is wide enough */

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -112,7 +112,11 @@ sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds) {
 void sxbp_walk_figure(
     const sxbp_figure_t* figure,
     size_t scale,
-    bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
+    bool( *plot_point_callback)(
+        sxbp_line_t* line,
+        sxbp_co_ord_t location,
+        void* callback_data
+    ),
     void* callback_data
 ) {
     // preconditional assertions
@@ -123,7 +127,7 @@ void sxbp_walk_figure(
     // start the line at the origin
     sxbp_co_ord_t location = sxbp_get_origin_from_bounds(bounds);
     // plot the first point of the line, if callback returned false then exit
-    if (!plot_point_callback(location, callback_data)) {
+    if (!plot_point_callback(&figure->lines[0], location, callback_data)) {
         return;
     }
     // for each line, plot separate points along their length
@@ -134,7 +138,9 @@ void sxbp_walk_figure(
             // move the location
             sxbp_move_location(&location, line.direction, 1);
             // plot a point, if callback returned false then exit
-            if (!plot_point_callback(location, callback_data)) {
+            if (
+                !plot_point_callback(&figure->lines[i], location, callback_data)
+            ) {
                 return;
             }
         }

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -88,8 +88,9 @@ sxbp_bounds_t sxbp_get_bounds(const sxbp_figure_t* figure, size_t scale);
 sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds);
 
 /*
- * private, walks the line of the figure, calling the callback with the
- * coördinates of each point of space occupied by the line of the figure
+ * private, walks the line of the figure, calling the callback with a pointer to
+ * that line and the coördinates of each point of space occupied by the line of
+ * the figure
  * the scale of the shape produced can be increased with the scale parameter
  * the shift parameter offsets the points produced
  * the callback should return false if it does not want the function to continue
@@ -98,7 +99,11 @@ sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds);
 void sxbp_walk_figure(
     const sxbp_figure_t* figure,
     size_t scale,
-    bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
+    bool( *plot_point_callback)(
+        sxbp_line_t* line,
+        sxbp_co_ord_t location,
+        void* callback_data
+    ),
     void* callback_data
 );
 

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -134,6 +134,12 @@ sxbp_result_t sxbp_make_bitmap_for_bounds(
 // private, prints out a bitmap to the given stream, for debugging
 void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream);
 
+// private, refines a figure using the 'grow from start' method
+sxbp_result_t sxbp_refine_figure_grow_from_start(
+    sxbp_figure_t* figure,
+    const sxbp_refine_figure_options_t* options
+);
+
 // private, refines a figure using the 'shrink from end' method
 sxbp_result_t sxbp_refine_figure_shrink_from_end(
     sxbp_figure_t* figure,

--- a/tests.c
+++ b/tests.c
@@ -87,6 +87,7 @@ int main(void) {
         sxbp_render_figure_to_bitmap(&figure, &bitmap);
         sxbp_refine_figure_options_t options = {
             .progress_callback = print_progress,
+            .refine_method = SXBP_REFINE_METHOD_GROW_FROM_START,
         };
         sxbp_result_t outcome = sxbp_refine_figure(&figure, &options);
         assert(outcome == SXBP_RESULT_OK);

--- a/tests.c
+++ b/tests.c
@@ -30,8 +30,8 @@ extern "C"{
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 static void print_progress(const sxbp_figure_t* figure, void* context) {
-    printf("%" PRIu32 "|", figure->lines_remaining);
-    fflush(stdout);
+    printf("(%" PRIu32 " lines remaining)\n", figure->lines_remaining);
+    // fflush(stdout);
 }
 // reënable all warnings
 #pragma GCC diagnostic pop

--- a/tests.c
+++ b/tests.c
@@ -31,7 +31,6 @@ extern "C"{
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 static void print_progress(const sxbp_figure_t* figure, void* context) {
     printf("(%" PRIu32 " lines remaining)\n", figure->lines_remaining);
-    fflush(stdout);
 }
 // reënable all warnings
 #pragma GCC diagnostic pop

--- a/tests.c
+++ b/tests.c
@@ -31,7 +31,7 @@ extern "C"{
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 static void print_progress(const sxbp_figure_t* figure, void* context) {
     printf("(%" PRIu32 " lines remaining)\n", figure->lines_remaining);
-    // fflush(stdout);
+    fflush(stdout);
 }
 // reënable all warnings
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This PR adds a new figure refinement method, a re-implementation of the original method from v0.27.0 of libsxbp, which tries extending all lines from length 1 until the shape doesn't collide.

**This PR is not complete!** The heavily commented sections detail the remaining work that needs to be done.

Broadly speaking, the remaining work involves completely implementing the optimisation code (currently written but unused) which allows smarter line extensions to be made in certain collision situations. This is currently blocked pending a correction of an oversight in one of its dependent functions.

The function that needs correcting is `sxbp_suggest_previous_length_callback()`. Once this is done, then `sxbp_suggest_previous_length()` can be updated to use the actual value returned by `sxbp_resolve_collision()`, which it currently ignores.