### PR TITLE
Remove disabling of -Wmissing-field-initializers warning flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: c
 # Run on Ubuntu 14.04 Trusty in Travis Container
 sudo: false
 dist: trusty
-# helps to use actual GCC on OSX (not Clang!)
-osx_image: xcode8
+# helps to use actual GCC on OSX (not Clang!) and Clang version 6
+osx_image: xcode10
 # build matrix with both OSes and Compilers
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 # On Ubuntu, run in Travis Container
-sudo: false
+# sudo: false
 # Use Ubuntu 16.04 Xenial (for Clang 7)
 dist: trusty
 # helps to use actual GCC on OSX (not Clang!) and Clang version 6
@@ -28,8 +28,8 @@ install:
   # install gcc-5 on OSX
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$CC" == "gcc" ]; then brew install gcc5; fi
 before_script:
-  # override $CC to use gcc-5
-  - if [ "$CC" == "gcc" ]; then export CC="gcc-5"; fi
+  # override $CC to use gcc-5 on OSX
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$CC" == "gcc" ]; then export CC="gcc-5"; fi
   - cmake .
 script:
   - make -j -k

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
-# Run on Ubuntu 14.04 Trusty in Travis Container
+# On Ubuntu, run in Travis Container
 sudo: false
+# Use Ubuntu 16.04 Xenial (for Clang 7)
 dist: trusty
 # helps to use actual GCC on OSX (not Clang!) and Clang version 6
 osx_image: xcode10
@@ -13,14 +14,6 @@ compiler:
   - gcc
 cache:
   - ccache
-addons:
-  apt:
-    sources:
-      # add PPAs with more up-to-date toolchains
-      - ubuntu-toolchain-r-test
-    packages:
-      # want gcc 5.x as 4.x gives incorrect warnings
-      - gcc-5
 # branches safelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
 # On Ubuntu, run in Travis Container
-# sudo: false
+sudo: false
 # Use Ubuntu 16.04 Xenial (for Clang 7)
-dist: trusty
+dist: xenial
 # helps to use actual GCC on OSX (not Clang!) and Clang version 6
 osx_image: xcode10
 # build matrix with both OSes and Compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "")
     enable_c_compiler_flag_if_supported("-Wc99-c11-compat")
     # enable warnings about mistakes in Doxygen documentation
     enable_c_compiler_flag_if_supported("-Wdocumentation")
-    # turn off spurious warnings from clang about missing field initialisers
-    enable_c_compiler_flag_if_supported("-Wno-missing-field-initializers")
     # convert all warnings into errors
     enable_c_compiler_flag_if_supported("-Werror")
 endif()


### PR DESCRIPTION
The bug in clang preventing this from being used has been fixed and released in Clang 6
https://bugs.llvm.org/show_bug.cgi?id=21689#c5