### PR TITLE
Don't compile C source code as C++!

### DIFF
--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -21,7 +21,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 /*
@@ -182,7 +182,3 @@ sxbp_result_t sxbp_begin_figure(
         }
     }
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -22,7 +22,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 sxbp_result_t sxbp_refine_figure(
@@ -46,7 +46,3 @@ sxbp_result_t sxbp_refine_figure(
             return SXBP_RESULT_FAIL_UNIMPLEMENTED;
     }
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -23,7 +23,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 // private datatype for passing context data into sxbp_walk_figure() callback
@@ -173,7 +173,3 @@ sxbp_result_t sxbp_refine_figure_shrink_from_end(
     // signal to caller that the call succeeded
     return SXBP_RESULT_OK;
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/render_figure.c
+++ b/sxbp/render_figure.c
@@ -20,7 +20,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 sxbp_result_t sxbp_render_figure(
@@ -42,7 +42,3 @@ sxbp_result_t sxbp_render_figure(
         render_callback_options
     );
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -20,7 +20,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 // private datatype for passing context data into sxbp_walk_figure() callback
@@ -90,7 +90,3 @@ sxbp_result_t sxbp_render_figure_to_bitmap(
     }
     return SXBP_RESULT_OK;
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/render_figure_to_null.c
+++ b/sxbp/render_figure_to_null.c
@@ -17,7 +17,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 /*
@@ -36,7 +36,3 @@ sxbp_result_t sxbp_render_figure_to_null(
 }
 // reënable all warnings
 #pragma GCC diagnostic pop
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/render_figure_to_pbm.c
+++ b/sxbp/render_figure_to_pbm.c
@@ -25,7 +25,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 // private, works out how many bytes are needed to store the given bitmap as PBM
@@ -208,7 +208,3 @@ sxbp_result_t sxbp_render_figure_to_pbm(
 }
 // reënable all warnings
 #pragma GCC diagnostic pop
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -19,7 +19,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 // private datatype for passing context data into sxbp_walk_figure() callback
@@ -415,7 +415,3 @@ sxbp_result_t sxbp_render_figure_to_svg(
 }
 // reënable all warnings
 #pragma GCC diagnostic pop
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -21,7 +21,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 // NOTE: All unsigned integer serialisation uses big-endian ordering
@@ -347,7 +347,3 @@ sxbp_result_t sxbp_load_figure(
         }
     }
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/sxbp.c
+++ b/sxbp/sxbp.c
@@ -16,7 +16,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 // Version numbers are passed as preprocessor definitions by CMake
@@ -35,7 +35,3 @@ const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT = {
 
 const sxbp_refine_method_t SXBP_REFINE_METHOD_DEFAULT =
     SXBP_REFINE_METHOD_SHRINK_FROM_END;
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -29,7 +29,7 @@
 
 
 #ifdef __cplusplus
-extern "C" {
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 const sxbp_vector_t SXBP_VECTOR_DIRECTIONS[4] = {
@@ -203,7 +203,3 @@ void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream) {
     }
     fprintf(stream, "\n");
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -23,7 +23,7 @@
 
 
 #ifdef __cplusplus
-extern "C"{
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
 bool sxbp_success(sxbp_result_t state) {
@@ -316,7 +316,3 @@ sxbp_result_t sxbp_copy_bitmap(
         return SXBP_RESULT_OK;
     }
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/tests.c
+++ b/tests.c
@@ -19,9 +19,8 @@
 
 
 #ifdef __cplusplus
-extern "C"{
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
-
 
 /*
  * disable GCC warning about the unused parameter, as this is a callback it must
@@ -121,7 +120,3 @@ int main(void) {
         return 0;
     }
 }
-
-#ifdef __cplusplus
-} // extern "C"
-#endif


### PR DESCRIPTION
Libsxbp can't be compiled by a C++ compiler anyhow, but to make it abundantly clear that it shouldn't be, replace all

```c
#ifdef __cplusplus
extern "C" {
#endif
```

blocks in non-header C source files with an error macro that is activated if `__cplusplus` is defined (and that the code is therefore being compiled with a C++ compiler).

I suppose I could just remove those macro sections completely, but seeing that I already have them in there, it could be nice to leave these explicit messages in there.

Closes #226