### PR TITLE
Make retrieval of file size more portable

### DIFF
--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -389,6 +389,9 @@ sxbp_result_t sxbp_copy_buffer(
  * @returns `SXBP_RESULT_FAIL_MEMORY` or `SXBP_RESULT_FAIL_IO` on failure to copy the file contents
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `file_handle` or `buffer` is
  * `NULL`
+ * @returns `SXBP_RESULT_FAIL_IO` if the file's size could not be determined
+ * @returns `SXBP_RESULT_FAIL_UNIMPLEMENTED` if the file size appears to be
+ * greater than 2GiB on Microsoft Windows only
  * @since v0.54.0
  */
 sxbp_result_t sxbp_buffer_from_file(

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -62,8 +62,13 @@ typedef struct sxbp_bounds_t {
  */
 extern const sxbp_vector_t SXBP_VECTOR_DIRECTIONS[4];
 
-// private, portably returns the size in bytes of the file at the given handle
-size_t sxbp_get_file_size(FILE* file_handle);
+/*
+ * private, portably retrieves the size in bytes of the file at the given handle
+ * and writes this out to file_size
+ * returns SXBP_RESULT_FAIL_IO if an error occurred
+ * returns SXBP_RESULT_OK if successful
+ */
+sxbp_result_t sxbp_get_file_size(FILE* file_handle, size_t* file_size);
 
 /*
  * private, updates the current figure bounds given the location of the end of

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -62,6 +62,9 @@ typedef struct sxbp_bounds_t {
  */
 extern const sxbp_vector_t SXBP_VECTOR_DIRECTIONS[4];
 
+// private, portably returns the size in bytes of the file at the given handle
+size_t sxbp_get_file_size(FILE* file_handle);
+
 /*
  * private, updates the current figure bounds given the location of the end of
  * the most recently-plotted line

--- a/sxbp/sxbp_internal_get_file_size.c
+++ b/sxbp/sxbp_internal_get_file_size.c
@@ -92,8 +92,10 @@ sxbp_result_t sxbp_get_file_size(FILE* file_handle, size_t* file_size) {
     // the file's size from the Windows API call will be stored in this struct
     LARGE_INTEGER file_size_info;
     // call the Windows API to check the file size
-    // TODO: error handling!
-    GetFileSizeEx((HANDLE)windows_file_handle, &file_size_info);
+    if (!GetFileSizeEx((HANDLE)windows_file_handle, &file_size_info)) {
+        // if it failed, return an error code
+        return SXBP_RESULT_FAIL_IO;
+    }
     /*
      * LARGE_INTEGER is actually a struct of two DWORDS (32-bits) with an extra
      * member which is 64 bits on 64-bit systems.
@@ -110,7 +112,6 @@ sxbp_result_t sxbp_get_file_size(FILE* file_handle, size_t* file_size) {
 }
 
 // Generic version
-// NOTE: I don't think this is the correct way to check two macro constants
 #else
 sxbp_result_t sxbp_get_file_size(FILE* file_handle, size_t* file_size) {
     // preconditional assertions

--- a/sxbp/sxbp_internal_get_file_size.c
+++ b/sxbp/sxbp_internal_get_file_size.c
@@ -1,0 +1,69 @@
+/*
+ * This source file forms part of sxbp, a library which generates experimental
+ * 2D spiral-like shapes based on input binary data.
+ */
+
+/**
+ * @internal
+ * @file
+ *
+ * @brief This source file provides the implementation for a function which
+ * tries to portably retrieve the size of a file, using OS-specific methods for
+ * POSIX and Windows, falling back to the standard library (which ironically is
+ * not portable due to the standard not requiring the host to meaningfully
+ * support SEEK_END in the ftell() function) in all other cases.
+ *
+ * @author Joshua Saxby <joshua.a.saxby@gmail.com>
+ * @date 2018
+ *
+ * @copyright Copyright (C) Joshua Saxby 2016-2017, 2018
+ *
+ * @copyright
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <assert.h>
+#include <stdlib.h>
+
+#include "sxbp_internal.h"
+
+
+#ifdef __cplusplus
+#error "This file is ISO C99. It should not be compiled with a C++ Compiler."
+#endif
+
+size_t sxbp_get_file_size(FILE* file_handle) {
+    // preconditional assertions
+    assert(file_handle != NULL);
+    size_t file_size = 0;
+    /*
+     * conditional compilation, hurrah!
+     * TODO: Check these macro constants, I literally made these ones up
+     */
+    #ifdef POSIX // POSIX implementation
+    // TODO: POSIX implementation goes here
+    assert(0 != 0);
+    #endif // ifdef POSIX
+
+    #ifndef POSIX
+    #ifdef WIN32 // Windows implementation
+    // TODO: Windows implementation goes here
+    #endif // ifdef WIN32
+
+    #ifndef WIN32 // Generic implementation
+    /*
+     * seek to end
+     * NOTE: This isn't portable due to lack of meaningful support of `SEEK_END`
+     */
+    fseek(file_handle, 0, SEEK_END);
+    // get size
+    file_size = (size_t)ftell(file_handle);
+    // seek to start again
+    fseek(file_handle, 0, SEEK_SET);
+    #endif // ifndef WIN32
+    #endif // ifndef POSIX
+
+    // return the calculated file size
+    return file_size;
+}

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -116,21 +116,6 @@ sxbp_result_t sxbp_copy_buffer(
     }
 }
 
-/*
- * private, works out and returns the size of the file referred to by the given
- * file handle
- */
-static size_t sxbp_get_file_size(FILE* file_handle) {
-    // seek to end
-    // NOTE: This isn't portable due to lack of meaningful support of `SEEK_END`
-    fseek(file_handle, 0, SEEK_END);
-    // get size
-    size_t file_size = (size_t)ftell(file_handle);
-    // seek to start again
-    fseek(file_handle, 0, SEEK_SET);
-    return file_size;
-}
-
 sxbp_result_t sxbp_buffer_from_file(
     FILE* file_handle,
     sxbp_buffer_t* const buffer

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -125,8 +125,15 @@ sxbp_result_t sxbp_buffer_from_file(
     SXBP_RETURN_FAIL_IF_NULL(buffer);
     // erase buffer
     sxbp_free_buffer(buffer);
-    // get the file's size
-    buffer->size = sxbp_get_file_size(file_handle);
+    /*
+     * get the file's size
+     * we'll store any errors encountered by this operation here
+     */
+    sxbp_result_t status = SXBP_RESULT_UNKNOWN;
+    if (!sxbp_check(sxbp_get_file_size(file_handle, &buffer->size), &status)) {
+        // handle error
+        return status;
+    }
     // allocate the buffer to this size and handle error if this failed
     if (!sxbp_success(sxbp_init_buffer(buffer))) {
         // allocation failed - this can only be a memory error


### PR DESCRIPTION
Put `sxbp_get_file_size()` in a separate source file and used conditional compilation to provide three different implementations of it:

- A POSIX/UNIX version which uses POSIX `fstat()`
- A Windows version which uses `GetFileSizeEx()` (and associated other WinAPI functions)
- A generic version using just the C standard library (but which might not work, as it uses `fseek()` and `SEEK_END`, which isn't required to be supported meaningfully).

### TODO:
- Test this on Windows
- Amend Windows version to return failure if file size > 2GiB on Win32 only, not Win64