### PR TITLE
Allow walking whole lines at once

### DIFF
--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -70,7 +70,12 @@ static sxbp_result_t sxbp_figure_collides(
         // set collided to false initially
         *data.collided = false;
         // begin walking the figure, use our callback function to handle points
-        sxbp_walk_figure(figure, 1, sxbp_figure_collides_callback, (void*)&data);
+        sxbp_walk_figure(
+            figure,
+            1,
+            false, // don't plot vertices only, we need all 1-unit sub-lines
+            sxbp_figure_collides_callback, (void*)&data
+        );
         // free the memory allocated for the bitmap
         sxbp_free_bitmap(&bitmap);
         return SXBP_RESULT_OK;

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -84,6 +84,8 @@ sxbp_result_t sxbp_render_figure_to_bitmap(
         sxbp_walk_figure(
             figure,
             2,
+            // don't plot vertices only, we need 1-unit sub-lines too for bitmap
+            false,
             sxbp_render_figure_to_bitmap_callback,
             (void*)&data
         );

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -171,7 +171,7 @@ static sxbp_result_t sxbp_write_svg_body_origin_dot(
 }
 
 // private, callback function for sxbp_write_svg_body_figure_line()
-static bool sxbp_render_figure_to_bitmap_callback(
+static bool sxbp_write_svg_body_figure_line_callback(
     sxbp_co_ord_t location,
     void* callback_data
 ) {
@@ -294,7 +294,7 @@ static sxbp_result_t sxbp_write_svg_body_figure_line(
         /*
         true, // plot vertices only, we don't need 1-unit long sub-lines for SVG
          */
-        sxbp_render_figure_to_bitmap_callback,
+        sxbp_write_svg_body_figure_line_callback,
         (void*)&data
     );
     // chop off the extra space at the end

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -290,6 +290,7 @@ static sxbp_result_t sxbp_write_svg_body_figure_line(
     sxbp_walk_figure(
         figure,
         2,
+        true, // plot vertices only, we don't need 1-unit long sub-lines for SVG
         sxbp_render_figure_to_bitmap_callback,
         (void*)&data
     );

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -290,7 +290,10 @@ static sxbp_result_t sxbp_write_svg_body_figure_line(
     sxbp_walk_figure(
         figure,
         2,
+        false, // TODO: change this to the commented-out line below:
+        /*
         true, // plot vertices only, we don't need 1-unit long sub-lines for SVG
+         */
         sxbp_render_figure_to_bitmap_callback,
         (void*)&data
     );

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -127,16 +127,27 @@ void sxbp_walk_figure(
     if (!plot_point_callback(location, callback_data)) {
         return;
     }
-    // for each line, plot separate points along their length
+    // for each line, plot one or more points along it (depending on plot mode)
     for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
         sxbp_line_t line = figure->lines[i];
         // scale the line's size
-        for (sxbp_figure_size_t l = 0; l < line.length * scale; l++) {
-            // move the location
-            sxbp_move_location(&location, line.direction, 1);
+        sxbp_length_t length = line.length * scale;
+        // if plotting vertices only, plot one point at the end of this line
+        if (plot_vertices_only) {
+            // move the location length amount of units
+            sxbp_move_location(&location, line.direction, length);
             // plot a point, if callback returned false then exit
             if (!plot_point_callback(location, callback_data)) {
                 return;
+            }
+        } else { // otherwise, plot one point along each one unit of line length
+            for (sxbp_length_t l = 0; l < length; l++) {
+                // move the location one unit
+                sxbp_move_location(&location, line.direction, 1);
+                // plot a point, if callback returned false then exit
+                if (!plot_point_callback(location, callback_data)) {
+                    return;
+                }
             }
         }
     }

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -112,6 +112,7 @@ sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds) {
 void sxbp_walk_figure(
     const sxbp_figure_t* figure,
     size_t scale,
+    bool plot_vertices_only,
     bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
     void* callback_data
 ) {

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -91,13 +91,16 @@ sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds);
  * private, walks the line of the figure, calling the callback with the
  * coördinates of each point of space occupied by the line of the figure
  * the scale of the shape produced can be increased with the scale parameter
- * the shift parameter offsets the points produced
+ * parameter plot_vertices_only, if true will cause the callback to only be
+ * called every time a vetice of the figure's line is encountered, i.e. the
+ * interface of each line segment with another
  * the callback should return false if it does not want the function to continue
  * walking the line, otherwise it should return true.
  */
 void sxbp_walk_figure(
     const sxbp_figure_t* figure,
     size_t scale,
+    bool plot_vertices_only,
     bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
     void* callback_data
 );


### PR DESCRIPTION
- Adds a new option to private function `sxbp_walk_figure()` which, when true, will cause walking to occur across line vertices only rather than every single-unit step.