### PR TITLE
Fix an edge-case identified where it is possible to copy a buffer to itself

### DIFF
--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -105,6 +105,10 @@ sxbp_result_t sxbp_copy_buffer(
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(from);
     SXBP_RETURN_FAIL_IF_NULL(to);
+    // copying a buffer to itself is not supported
+    if (from == to) {
+        return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+    }
     // before we do anything else, make sure 'to' has been freed
     sxbp_free_buffer(to);
     // copy across the size
@@ -240,6 +244,10 @@ sxbp_result_t sxbp_copy_figure(
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(from);
     SXBP_RETURN_FAIL_IF_NULL(to);
+    // copying a figure to itself is not supported
+    if (from == to) {
+        return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+    }
     // before we do anything else, make sure 'to' has been freed
     sxbp_free_figure(to);
     // copy across the static members
@@ -337,6 +345,10 @@ sxbp_result_t sxbp_copy_bitmap(
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(from);
     SXBP_RETURN_FAIL_IF_NULL(to);
+    // copying a bitmap to itself is not supported
+    if (from == to) {
+        return SXBP_RESULT_FAIL_UNIMPLEMENTED;
+    }
     // before we do anything else, make sure 'to' has been freed
     sxbp_free_bitmap(to);
     // copy across width and height

--- a/tests/test_bitmap.c
+++ b/tests/test_bitmap.c
@@ -269,7 +269,7 @@ START_TEST(test_copy_bitmap_to_itself) {
     // store pixels pointer for checking later
     bool** pixels = bitmap.pixels;
 
-    // NOTE: copying the bitmap to itself
+    // try and copy the bitmap to itself
     sxbp_result_t result = sxbp_copy_bitmap(&bitmap, &bitmap);
 
     // not implemented error code should be returned

--- a/tests/test_bitmap.c
+++ b/tests/test_bitmap.c
@@ -251,6 +251,38 @@ START_TEST(test_copy_bitmap_height_zero_only) {
     ck_assert_ptr_null(to.pixels);
 } END_TEST
 
+START_TEST(test_copy_bitmap_to_itself) {
+    sxbp_bitmap_t bitmap = { .width = 32, .height = 64, .pixels = NULL, };
+    /*
+     * allocate the bitmap -if this fails then we'll abort here because this
+     * test case is not testing the init function
+     */
+    if (sxbp_init_bitmap(&bitmap) != SXBP_RESULT_OK) {
+        ck_abort_msg("Unable to allocate bitmap");
+    }
+    // populate the bitmap with random pixels
+    for (sxbp_figure_size_t x = 0; x < bitmap.width; x++) {
+        for (sxbp_figure_size_t y = 0; y < bitmap.height; y++) {
+            bitmap.pixels[x][y] = rand() % 2;
+        }
+    }
+    // store pixels pointer for checking later
+    bool** pixels = bitmap.pixels;
+
+    // NOTE: copying the bitmap to itself
+    sxbp_result_t result = sxbp_copy_bitmap(&bitmap, &bitmap);
+
+    // not implemented error code should be returned
+    ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
+    // pixels have not been deallocated
+    ck_assert_ptr_nonnull(bitmap.pixels);
+    // pixels pointer remains unchanged
+    ck_assert(bitmap.pixels == pixels);
+
+    // cleanup
+    sxbp_free_bitmap(&bitmap);
+} END_TEST
+
 Suite* make_bitmap_suite(void) {
     // Test cases for bitmap data type
     Suite* test_suite = suite_create("Bitmap");
@@ -280,6 +312,7 @@ Suite* make_bitmap_suite(void) {
     tcase_add_test(copy_bitmap, test_copy_bitmap_pixels_null);
     tcase_add_test(copy_bitmap, test_copy_bitmap_width_zero_only);
     tcase_add_test(copy_bitmap, test_copy_bitmap_height_zero_only);
+    tcase_add_test(copy_bitmap, test_copy_bitmap_to_itself);
     suite_add_tcase(test_suite, copy_bitmap);
 
     return test_suite;


### PR DESCRIPTION
FIxes #243 