### PR TITLE
Change type name format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     packages:
       - gcc5
       - check
+    update: true
 # branches safelist
 branches:
   only:

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -35,11 +35,11 @@ typedef enum sxbp_rotation_t {
 } sxbp_rotation_t;
 
 // private, builds a line from a direction and length
-static sxbp_line_t sxbp_make_line(
-    sxbp_direction_t direction,
-    sxbp_length_t length
+static sxbp_Line sxbp_make_line(
+    sxbp_Direction direction,
+    sxbp_Length length
 ) {
-    return (sxbp_line_t){ .direction = direction, .length = length, };
+    return (sxbp_Line){ .direction = direction, .length = length, };
 }
 
 // private, converts a binary bit into a rotational direction
@@ -51,20 +51,20 @@ static sxbp_rotation_t sxbp_rotation_from_bit(bool bit) {
  * private, returns the new cartesian direction that will be faced after
  * turning from the given cartesian direction by the given rotational direction
  */
-static sxbp_direction_t sxbp_change_line_direction(
-    sxbp_direction_t current,
+static sxbp_Direction sxbp_change_line_direction(
+    sxbp_Direction current,
     sxbp_rotation_t turn
 ) {
-    return (current + (sxbp_direction_t)turn) % 4;
+    return (current + (sxbp_Direction)turn) % 4;
 }
 
 /*
  * private, works out how long the next line should be to ensure no lines after
  * it collide
  */
-static sxbp_length_t sxbp_next_length(
+static sxbp_Length sxbp_next_length(
     sxbp_co_ord_t location,
-    sxbp_direction_t direction,
+    sxbp_Direction direction,
     sxbp_bounds_t bounds
 ) {
     // preconditional assertions --direction should be one of the enum values
@@ -94,12 +94,12 @@ static sxbp_length_t sxbp_next_length(
  * setting line directions and lengths such that there are no collisions and
  * each line is at least 1 unit long
  */
-static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
+static void sxbp_plot_lines(const sxbp_Buffer* data, sxbp_Figure* figure) {
     // loop state variables
     sxbp_co_ord_t location = { 0 }; // where the end of the last line is
     sxbp_bounds_t bounds = { 0 }; // the bounds of the line traced so far
     // the first line is always an up line - this is for orientation purposes
-    sxbp_direction_t facing = SXBP_UP;
+    sxbp_Direction facing = SXBP_UP;
     // add first line to the figure
     figure->lines[0] = sxbp_make_line(facing, 1);
     // update the location
@@ -111,14 +111,14 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
      * make the spiral pattern, also deducing the length to set these to to
      * avoid any collisions
      */
-    for (sxbp_figure_size_t s = 0; s < data->size; s++) {
+    for (sxbp_FigureSize s = 0; s < data->size; s++) {
         // byte-level loop
         for (uint8_t b = 0; b < 8; b++) {
             // bit level loop - extract the bit
             uint8_t e = 7 - b; // which power of two to use with bit mask
             bool bit = (data->bytes[s] & (1 << e)) >> e; // the current bit
             // this is the line index, derived from the bit of data we're on
-            sxbp_figure_size_t index = (s * 8) + (sxbp_figure_size_t)b + 1;
+            sxbp_FigureSize index = (s * 8) + (sxbp_FigureSize)b + 1;
             // do bounds-checking on the index, return early if out of bounds
             if (index >= figure->size) {
                 return;
@@ -128,9 +128,9 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
             // calculate the new direction
             facing = sxbp_change_line_direction(facing, rotation);
             // calculate what length this line should be
-            sxbp_length_t length = sxbp_next_length(location, facing, bounds);
+            sxbp_Length length = sxbp_next_length(location, facing, bounds);
             // make line
-            sxbp_line_t line = sxbp_make_line(facing, length);
+            sxbp_Line line = sxbp_make_line(facing, length);
             // add line to figure
             figure->lines[index] = line;
             // update location and bounds
@@ -140,10 +140,10 @@ static void sxbp_plot_lines(const sxbp_buffer_t* data, sxbp_figure_t* figure) {
     }
 }
 
-sxbp_result_t sxbp_begin_figure(
-    const sxbp_buffer_t* data,
-    const sxbp_begin_figure_options_t* options,
-    sxbp_figure_t* figure
+sxbp_Result sxbp_begin_figure(
+    const sxbp_Buffer* data,
+    const sxbp_BeginFigureOptions* options,
+    sxbp_Figure* figure
 ) {
     // data and figure must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(data);

--- a/sxbp/begin_figure.c
+++ b/sxbp/begin_figure.c
@@ -29,10 +29,10 @@
  * This makes the maths for discerning the line directions read particularly
  * well and intuitively.
  */
-typedef enum sxbp_rotation_t {
+typedef enum sxbp_Rotation {
     SXBP_ANTI_CLOCKWISE = -1, // The rotational direction 'ANTI-CLOCKWISE'
     SXBP_CLOCKWISE = 1, // The rotational direction 'CLOCKWISE'
-} sxbp_rotation_t;
+} sxbp_Rotation;
 
 // private, builds a line from a direction and length
 static sxbp_Line sxbp_make_line(
@@ -43,7 +43,7 @@ static sxbp_Line sxbp_make_line(
 }
 
 // private, converts a binary bit into a rotational direction
-static sxbp_rotation_t sxbp_rotation_from_bit(bool bit) {
+static sxbp_Rotation sxbp_rotation_from_bit(bool bit) {
     return bit == 0 ? SXBP_CLOCKWISE : SXBP_ANTI_CLOCKWISE;
 }
 
@@ -53,7 +53,7 @@ static sxbp_rotation_t sxbp_rotation_from_bit(bool bit) {
  */
 static sxbp_Direction sxbp_change_line_direction(
     sxbp_Direction current,
-    sxbp_rotation_t turn
+    sxbp_Rotation turn
 ) {
     return (current + (sxbp_Direction)turn) % 4;
 }
@@ -63,9 +63,9 @@ static sxbp_Direction sxbp_change_line_direction(
  * it collide
  */
 static sxbp_Length sxbp_next_length(
-    sxbp_co_ord_t location,
+    sxbp_CoOrd location,
     sxbp_Direction direction,
-    sxbp_bounds_t bounds
+    sxbp_Bounds bounds
 ) {
     // preconditional assertions --direction should be one of the enum values
     assert(direction >= SXBP_UP);
@@ -96,8 +96,8 @@ static sxbp_Length sxbp_next_length(
  */
 static void sxbp_plot_lines(const sxbp_Buffer* data, sxbp_Figure* figure) {
     // loop state variables
-    sxbp_co_ord_t location = { 0 }; // where the end of the last line is
-    sxbp_bounds_t bounds = { 0 }; // the bounds of the line traced so far
+    sxbp_CoOrd location = { 0 }; // where the end of the last line is
+    sxbp_Bounds bounds = { 0 }; // the bounds of the line traced so far
     // the first line is always an up line - this is for orientation purposes
     sxbp_Direction facing = SXBP_UP;
     // add first line to the figure
@@ -124,7 +124,7 @@ static void sxbp_plot_lines(const sxbp_Buffer* data, sxbp_Figure* figure) {
                 return;
             }
             // set rotation direction based on the current bit
-            sxbp_rotation_t rotation = sxbp_rotation_from_bit(bit);
+            sxbp_Rotation rotation = sxbp_rotation_from_bit(bit);
             // calculate the new direction
             facing = sxbp_change_line_direction(facing, rotation);
             // calculate what length this line should be

--- a/sxbp/refine_figure.c
+++ b/sxbp/refine_figure.c
@@ -25,15 +25,15 @@
 #error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
-sxbp_result_t sxbp_refine_figure(
-    sxbp_figure_t* figure,
-    const sxbp_refine_figure_options_t* options
+sxbp_Result sxbp_refine_figure(
+    sxbp_Figure* figure,
+    const sxbp_RefineFigureOptions* options
 ) {
     // figure and figure's lines must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(figure);
     SXBP_RETURN_FAIL_IF_NULL(figure->lines);
     // work out which refinement method to use
-    sxbp_refine_method_t method = SXBP_REFINE_METHOD_DEFAULT;
+    sxbp_RefineMethod method = SXBP_REFINE_METHOD_DEFAULT;
     if (options != NULL && options->refine_method != SXBP_REFINE_METHOD_ANY) {
         method = options->refine_method;
     }

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -33,7 +33,7 @@ typedef struct figure_collides_context {
 } figure_collides_context;
 
 // private, callback function for sxbp_figure_collides()
-static bool sxbp_figure_collides_callback(sxbp_co_ord_t location, void* data) {
+static bool sxbp_figure_collides_callback(sxbp_CoOrd location, void* data) {
     // cast void pointer to a pointer to our context structure
     figure_collides_context* callback_data = (figure_collides_context*)data;
     // check if there's already a pixel here
@@ -56,7 +56,7 @@ static sxbp_Result sxbp_figure_collides(
     bool* collided
 ) {
     // get figure bounds first
-    sxbp_bounds_t bounds = sxbp_get_bounds(figure, 1);
+    sxbp_Bounds bounds = sxbp_get_bounds(figure, 1);
     // build bitmap for bounds
     sxbp_Bitmap bitmap = sxbp_blank_bitmap();
     if (!sxbp_success(sxbp_make_bitmap_for_bounds(bounds, &bitmap))) {

--- a/sxbp/refine_figure_shrink_from_end.c
+++ b/sxbp/refine_figure_shrink_from_end.c
@@ -28,7 +28,7 @@
 
 // private datatype for passing context data into sxbp_walk_figure() callback
 typedef struct figure_collides_context {
-    sxbp_bitmap_t* image;
+    sxbp_Bitmap* image;
     bool* collided;
 } figure_collides_context;
 
@@ -51,14 +51,14 @@ static bool sxbp_figure_collides_callback(sxbp_co_ord_t location, void* data) {
 }
 
 // private, sets collided to true if the figure's line collides with itself
-static sxbp_result_t sxbp_figure_collides(
-    const sxbp_figure_t* figure,
+static sxbp_Result sxbp_figure_collides(
+    const sxbp_Figure* figure,
     bool* collided
 ) {
     // get figure bounds first
     sxbp_bounds_t bounds = sxbp_get_bounds(figure, 1);
     // build bitmap for bounds
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    sxbp_Bitmap bitmap = sxbp_blank_bitmap();
     if (!sxbp_success(sxbp_make_bitmap_for_bounds(bounds, &bitmap))) {
         // a memory allocation error occurred
         return SXBP_RESULT_FAIL_MEMORY;
@@ -87,22 +87,22 @@ static sxbp_result_t sxbp_figure_collides(
  * if it succeeds, it will call itself recursively for each line after l from
  * max to l, in that order.
  */
-static sxbp_result_t sxbp_attempt_line_shorten(
-    sxbp_figure_t* figure,
-    const sxbp_figure_size_t l,
-    const sxbp_figure_size_t max
+static sxbp_Result sxbp_attempt_line_shorten(
+    sxbp_Figure* figure,
+    const sxbp_FigureSize l,
+    const sxbp_FigureSize max
 ) {
-    sxbp_line_t* line = &figure->lines[l];
+    sxbp_Line* line = &figure->lines[l];
     // it only makes sense to try and shorten lines longer than 1
     if (line->length > 1) {
         // we'll need this later to check if we were actually able to shorten it
-        sxbp_length_t original_length = line->length;
+        sxbp_Length original_length = line->length;
         // as an ambitious first step, set to 1 (try best case scenario first)
         line->length = 1;
         // check if it collided
         bool collided = false;
         // we'll store any errors encountered by this function here
-        sxbp_result_t status = SXBP_RESULT_UNKNOWN;
+        sxbp_Result status = SXBP_RESULT_UNKNOWN;
         if (!sxbp_check(sxbp_figure_collides(figure, &collided), &status)) {
             // handle error
             return status;
@@ -131,7 +131,7 @@ static sxbp_result_t sxbp_attempt_line_shorten(
              */
             if (line->length < original_length) {
                 // try and shorten other lines some more
-                for (sxbp_figure_size_t i = max; i >= l; i--) {
+                for (sxbp_FigureSize i = max; i >= l; i--) {
                     // handle any errors returned by the call
                     if (
                         !sxbp_check(
@@ -147,14 +147,14 @@ static sxbp_result_t sxbp_attempt_line_shorten(
     return SXBP_RESULT_OK;
 }
 
-sxbp_result_t sxbp_refine_figure_shrink_from_end(
-    sxbp_figure_t* figure,
-    const sxbp_refine_figure_options_t* options
+sxbp_Result sxbp_refine_figure_shrink_from_end(
+    sxbp_Figure* figure,
+    const sxbp_RefineFigureOptions* options
 ) {
     // variable to store any errors in
-    sxbp_result_t status = SXBP_RESULT_UNKNOWN;
+    sxbp_Result status = SXBP_RESULT_UNKNOWN;
     // iterate over lines backwards - we don't care about line 0
-    for (sxbp_figure_size_t i = figure->size - 1; i > 0; i--) {
+    for (sxbp_FigureSize i = figure->size - 1; i > 0; i--) {
         // try and shorten it, or return error if not
         if (
             !sxbp_check(

--- a/sxbp/render_figure.c
+++ b/sxbp/render_figure.c
@@ -23,11 +23,11 @@
 #error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
-sxbp_result_t sxbp_render_figure(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
+sxbp_Result sxbp_render_figure(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
     sxbp_figure_renderer_t render_callback,
-    const sxbp_render_options_t* const render_options,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 ) {
     // figure, buffer and render_callback must not be NULL

--- a/sxbp/render_figure.c
+++ b/sxbp/render_figure.c
@@ -26,7 +26,7 @@
 sxbp_Result sxbp_render_figure(
     const sxbp_Figure* const figure,
     sxbp_Buffer* const buffer,
-    sxbp_figure_renderer_t render_callback,
+    sxbp_FigureRenderer render_callback,
     const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 ) {

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -36,7 +36,7 @@ typedef struct render_figure_to_bitmap_context {
 
 // private, callback function for sxbp_render_figure_to_bitmap()
 static bool sxbp_render_figure_to_bitmap_callback(
-    sxbp_co_ord_t location,
+    sxbp_CoOrd location,
     void* callback_data
 ) {
     // cast void pointer to a pointer to our context structure
@@ -68,7 +68,7 @@ sxbp_Result sxbp_render_figure_to_bitmap(
     // erase the bitmap structure first just in case
     sxbp_free_bitmap(bitmap);
     // get figure bounds, at scale 2
-    sxbp_bounds_t bounds = sxbp_get_bounds(figure, 2);
+    sxbp_Bounds bounds = sxbp_get_bounds(figure, 2);
     // build bitmap for bounds
     if (!sxbp_success(sxbp_make_bitmap_for_bounds(bounds, bitmap))) {
         // couldn't allocate memory, return error early

--- a/sxbp/render_figure_to_bitmap.c
+++ b/sxbp/render_figure_to_bitmap.c
@@ -25,7 +25,7 @@
 
 // private datatype for passing context data into sxbp_walk_figure() callback
 typedef struct render_figure_to_bitmap_context {
-    sxbp_bitmap_t* image; // the bitmap to draw to
+    sxbp_Bitmap* image; // the bitmap to draw to
     /*
      * the following unusual fields facilitate a low-tech way of skipping the
      * second pixel --this is done to assist in orientation of the shape
@@ -52,15 +52,15 @@ static bool sxbp_render_figure_to_bitmap_callback(
         // plot the pixel, but flip the y coördinate
         data->image
             ->pixels[location.x]
-            [data->image->height - 1 - (sxbp_figure_dimension_t)location.y] = true;
+            [data->image->height - 1 - (sxbp_FigureDimension)location.y] = true;
     }
     // return true --we always want to continue
     return true;
 }
 
-sxbp_result_t sxbp_render_figure_to_bitmap(
-    const sxbp_figure_t* figure,
-    sxbp_bitmap_t* bitmap
+sxbp_Result sxbp_render_figure_to_bitmap(
+    const sxbp_Figure* figure,
+    sxbp_Bitmap* bitmap
 ) {
     // figure and bitmap must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(figure);

--- a/sxbp/render_figure_to_null.c
+++ b/sxbp/render_figure_to_null.c
@@ -26,10 +26,10 @@
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-sxbp_result_t sxbp_render_figure_to_null(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+sxbp_Result sxbp_render_figure_to_null(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 ) {
     return SXBP_RESULT_FAIL_UNIMPLEMENTED;

--- a/sxbp/render_figure_to_pbm.c
+++ b/sxbp/render_figure_to_pbm.c
@@ -143,7 +143,7 @@ static void sxbp_write_pbm_data(
 }
 
 // private, serialises a bitmap to PBM image data
-static sxbp_Result sxbp_Bitmapo_pbm(
+static sxbp_Result sxbp_bitmap_to_pbm(
     const sxbp_Bitmap* const bitmap,
     sxbp_Buffer* const buffer
 ) {
@@ -200,7 +200,7 @@ sxbp_Result sxbp_render_figure_to_pbm(
         return error;
     } else {
         // rasterisation was successful, now convert the raw bitmap to PBM
-        sxbp_Result outcome = sxbp_Bitmapo_pbm(&bitmap, buffer);
+        sxbp_Result outcome = sxbp_bitmap_to_pbm(&bitmap, buffer);
         // free the bitmap and return the result code
         sxbp_free_bitmap(&bitmap);
         return outcome;

--- a/sxbp/render_figure_to_pbm.c
+++ b/sxbp/render_figure_to_pbm.c
@@ -50,13 +50,13 @@ static size_t sxbp_get_pbm_image_size(
 }
 
 // private, tries to allocate data for the whole image and writes the header
-static sxbp_result_t sxbp_write_pbm_header(
-    const sxbp_bitmap_t* const bitmap,
-    sxbp_buffer_t* const buffer,
+static sxbp_Result sxbp_write_pbm_header(
+    const sxbp_Bitmap* const bitmap,
+    sxbp_Buffer* const buffer,
     size_t* bytes_per_row_ptr,
     size_t* index_ptr
 ) {
-    sxbp_result_t error;
+    sxbp_Result error;
     /*
      * allocate two char arrays for the width and height strings - these may be
      * up to 10 characters each (max uint32_t is 10 digits long), so allocate 2
@@ -119,8 +119,8 @@ static sxbp_result_t sxbp_write_pbm_header(
 
 // private, writes the image data out to the buffer
 static void sxbp_write_pbm_data(
-    const sxbp_bitmap_t* const bitmap,
-    sxbp_buffer_t* const buffer,
+    const sxbp_Bitmap* const bitmap,
+    sxbp_Buffer* const buffer,
     size_t bytes_per_row,
     size_t index
 ) {
@@ -143,11 +143,11 @@ static void sxbp_write_pbm_data(
 }
 
 // private, serialises a bitmap to PBM image data
-static sxbp_result_t sxbp_bitmap_to_pbm(
-    const sxbp_bitmap_t* const bitmap,
-    sxbp_buffer_t* const buffer
+static sxbp_Result sxbp_Bitmapo_pbm(
+    const sxbp_Bitmap* const bitmap,
+    sxbp_Buffer* const buffer
 ) {
-    sxbp_result_t error;
+    sxbp_Result error;
     // index into the image data
     size_t index = 0;
     // we'll use this later to track how many bytes we pack each row into
@@ -182,25 +182,25 @@ static sxbp_result_t sxbp_bitmap_to_pbm(
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-sxbp_result_t sxbp_render_figure_to_pbm(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+sxbp_Result sxbp_render_figure_to_pbm(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 ) {
     // figure, figure lines and buffer must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(figure);
     SXBP_RETURN_FAIL_IF_NULL(figure->lines);
     SXBP_RETURN_FAIL_IF_NULL(buffer);
-    sxbp_result_t error;
+    sxbp_Result error;
     // rasterise the figure to bitmap first of all
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    sxbp_Bitmap bitmap = sxbp_blank_bitmap();
     if (!sxbp_check(sxbp_render_figure_to_bitmap(figure, &bitmap), &error)) {
         // catch and return raised error
         return error;
     } else {
         // rasterisation was successful, now convert the raw bitmap to PBM
-        sxbp_result_t outcome = sxbp_bitmap_to_pbm(&bitmap, buffer);
+        sxbp_Result outcome = sxbp_Bitmapo_pbm(&bitmap, buffer);
         // free the bitmap and return the result code
         sxbp_free_bitmap(&bitmap);
         return outcome;

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -116,7 +116,7 @@ static sxbp_Result sxbp_write_svg_body_origin_dot(
         "    />\n"
     );
     // get the coördinates of the origin dot
-    sxbp_co_ord_t origin = sxbp_get_origin_from_bounds(
+    sxbp_CoOrd origin = sxbp_get_origin_from_bounds(
         sxbp_get_bounds(figure, 2)
     );
     sxbp_FigureDimension origin_x = (sxbp_FigureDimension)origin.x;
@@ -172,7 +172,7 @@ static sxbp_Result sxbp_write_svg_body_origin_dot(
 
 // private, callback function for sxbp_write_svg_body_figure_line()
 static bool sxbp_write_svg_body_figure_line_callback(
-    sxbp_co_ord_t location,
+    sxbp_CoOrd location,
     void* callback_data
 ) {
     // cast void pointer to a pointer to our context structure
@@ -392,7 +392,7 @@ sxbp_Result sxbp_render_figure_to_svg(
      * needs to have the same dimensions and scale.
      */
     // get figure bounds, at scale 2
-    sxbp_bounds_t bounds = sxbp_get_bounds(figure, 2);
+    sxbp_Bounds bounds = sxbp_get_bounds(figure, 2);
     // calculate width and height of the image from the bounds
     sxbp_FigureDimension width = 0;
     sxbp_FigureDimension height = 0;

--- a/sxbp/render_figure_to_svg.c
+++ b/sxbp/render_figure_to_svg.c
@@ -24,19 +24,19 @@
 
 // private datatype for passing context data into sxbp_walk_figure() callback
 typedef struct write_polyline_context {
-    sxbp_buffer_t* buffer; // the buffer to write out SVG code fragments to
-    sxbp_figure_dimension_t height; // the height of the image being written
+    sxbp_Buffer* buffer; // the buffer to write out SVG code fragments to
+    sxbp_FigureDimension height; // the height of the image being written
     size_t current_point; // the index of the point currently being rendered
-    sxbp_result_t error; // any error conditions that occur will be stored here
+    sxbp_Result error; // any error conditions that occur will be stored here
 } write_polyline_context;
 
 // private, given a figure and a buffer, writes out the SVG header to the buffer
-static sxbp_result_t sxbp_write_svg_head(
-    sxbp_figure_dimension_t width,
-    sxbp_figure_dimension_t height,
-    sxbp_buffer_t* const buffer
+static sxbp_Result sxbp_write_svg_head(
+    sxbp_FigureDimension width,
+    sxbp_FigureDimension height,
+    sxbp_Buffer* const buffer
 ) {
-    sxbp_result_t error;
+    sxbp_Result error;
     // the fixed data that is always at the start of the file
     const char* head = (
         "<svg\n"
@@ -100,10 +100,10 @@ static sxbp_result_t sxbp_write_svg_head(
  * private, given a figure and a buffer, writes out the SVG code for the origin
  * dot of the figure to the buffer
  */
-static sxbp_result_t sxbp_write_svg_body_origin_dot(
-    const sxbp_figure_t* const figure,
-    sxbp_figure_dimension_t height,
-    sxbp_buffer_t* const buffer
+static sxbp_Result sxbp_write_svg_body_origin_dot(
+    const sxbp_Figure* const figure,
+    sxbp_FigureDimension height,
+    sxbp_Buffer* const buffer
 ) {
     // generate the code for the origin dot
     const char* origin_dot = (
@@ -119,10 +119,10 @@ static sxbp_result_t sxbp_write_svg_body_origin_dot(
     sxbp_co_ord_t origin = sxbp_get_origin_from_bounds(
         sxbp_get_bounds(figure, 2)
     );
-    sxbp_figure_dimension_t origin_x = (sxbp_figure_dimension_t)origin.x;
+    sxbp_FigureDimension origin_x = (sxbp_FigureDimension)origin.x;
     // y coördinate is flipped
-    sxbp_figure_dimension_t origin_y =
-        height - 1 - (sxbp_figure_dimension_t)origin.y;
+    sxbp_FigureDimension origin_y =
+        height - 1 - (sxbp_FigureDimension)origin.y;
     char origin_x_str[11], origin_y_str[11];
     size_t origin_x_length, origin_y_length = 0;
     // stringify the origin dot x/y values
@@ -181,10 +181,10 @@ static bool sxbp_write_svg_body_figure_line_callback(
     // skip plotting the first and second line segments
     if (data->current_point >= 2) {
         // stringify this point's coördinates
-        sxbp_figure_dimension_t x = (sxbp_figure_dimension_t)location.x;
+        sxbp_FigureDimension x = (sxbp_FigureDimension)location.x;
         // y coördinate is flipped
-        sxbp_figure_dimension_t y =
-            data->height - 1 - (sxbp_figure_dimension_t)location.y;
+        sxbp_FigureDimension y =
+            data->height - 1 - (sxbp_FigureDimension)location.y;
         char x_str[11], y_str[11];
         size_t x_str_length, y_str_length = 0;
         if (
@@ -205,7 +205,7 @@ static bool sxbp_write_svg_body_figure_line_callback(
             + 1 // NUL-terminator
         );
         // de-reference buffer pointer for ease
-        sxbp_buffer_t* buffer = data->buffer;
+        sxbp_Buffer* buffer = data->buffer;
         // try and allocate more memory
         if (
             !sxbp_success(
@@ -246,10 +246,10 @@ static bool sxbp_write_svg_body_figure_line_callback(
  * private, given a figure and a buffer, writes out the SVG code for the
  * figure's line to the buffer
  */
-static sxbp_result_t sxbp_write_svg_body_figure_line(
-    const sxbp_figure_t* const figure,
-    sxbp_figure_dimension_t height,
-    sxbp_buffer_t* const buffer
+static sxbp_Result sxbp_write_svg_body_figure_line(
+    const sxbp_Figure* const figure,
+    sxbp_FigureDimension height,
+    sxbp_Buffer* const buffer
 ) {
     const char* polyline_boilerplate = (
         "    <polyline\n"
@@ -309,13 +309,13 @@ static sxbp_result_t sxbp_write_svg_body_figure_line(
  * private, given a figure and a buffer, writes out the bulk of the SVG markup
  * to the buffer
  */
-static sxbp_result_t sxbp_write_svg_body(
-    const sxbp_figure_t* const figure,
-    sxbp_figure_dimension_t height,
-    sxbp_buffer_t* const buffer
+static sxbp_Result sxbp_write_svg_body(
+    const sxbp_Figure* const figure,
+    sxbp_FigureDimension height,
+    sxbp_Buffer* const buffer
 ) {
     // any errors encountered will be stored here
-    sxbp_result_t error;
+    sxbp_Result error;
     // write the origin dot
     if (!sxbp_check(
         sxbp_write_svg_body_origin_dot(figure, height, buffer), &error)
@@ -335,7 +335,7 @@ static sxbp_result_t sxbp_write_svg_body(
 }
 
 // private, given a buffer, writes out the end of the SVG file to the buffer
-static sxbp_result_t sxbp_write_svg_tail(sxbp_buffer_t* const buffer) {
+static sxbp_Result sxbp_write_svg_tail(sxbp_Buffer* const buffer) {
     /*
      * the 'tail' of the SVG images produced by libsxbp never change, the only
      * way this function can fail is if reallocating memory was refused
@@ -348,7 +348,7 @@ static sxbp_result_t sxbp_write_svg_tail(sxbp_buffer_t* const buffer) {
     );
     size_t tail_length = strlen(tail);
     // any errors encountered will be stored here
-    sxbp_result_t error;
+    sxbp_Result error;
     // try and reallocate memory to include the tail
     if (
         !sxbp_check(
@@ -371,10 +371,10 @@ static sxbp_result_t sxbp_write_svg_tail(sxbp_buffer_t* const buffer) {
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-sxbp_result_t sxbp_render_figure_to_svg(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+sxbp_Result sxbp_render_figure_to_svg(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 ) {
     // figure, figure lines and buffer must not be NULL
@@ -382,7 +382,7 @@ sxbp_result_t sxbp_render_figure_to_svg(
     SXBP_RETURN_FAIL_IF_NULL(figure->lines);
     SXBP_RETURN_FAIL_IF_NULL(buffer);
     // any errors encountered will be stored here
-    sxbp_result_t error;
+    sxbp_Result error;
     /*
      * because SVG is a vector-based format, this backend differs from the
      * others as we don't need to plot a bunch of pixels, instead we need to use
@@ -394,8 +394,8 @@ sxbp_result_t sxbp_render_figure_to_svg(
     // get figure bounds, at scale 2
     sxbp_bounds_t bounds = sxbp_get_bounds(figure, 2);
     // calculate width and height of the image from the bounds
-    sxbp_figure_dimension_t width = 0;
-    sxbp_figure_dimension_t height = 0;
+    sxbp_FigureDimension width = 0;
+    sxbp_FigureDimension height = 0;
     sxbp_get_size_from_bounds(bounds, &width, &height);
     // write image head, including everything up to the line's points
     if (!sxbp_check(

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -36,11 +36,11 @@ static const size_t SXBP_FILE_HEADER_SIZE = (
     4 + // number of seconds spent solving, 32 bit uint
     4 // number of seconds accuracy of solve time, 32 bit uint
 );
-static const size_t sxbp_Line_PACK_SIZE = 4;
+static const size_t SXBP_LINE_PACK_SIZE = 4;
 
 // private, returns the size in bytes needed to serialise a figure
 static size_t sxbp_get_figure_serialised_size(const sxbp_Figure* figure) {
-    return SXBP_FILE_HEADER_SIZE + sxbp_Line_PACK_SIZE * figure->size;
+    return SXBP_FILE_HEADER_SIZE + SXBP_LINE_PACK_SIZE * figure->size;
 }
 
 /*

--- a/sxbp/serialisation.c
+++ b/sxbp/serialisation.c
@@ -36,11 +36,11 @@ static const size_t SXBP_FILE_HEADER_SIZE = (
     4 + // number of seconds spent solving, 32 bit uint
     4 // number of seconds accuracy of solve time, 32 bit uint
 );
-static const size_t SXBP_LINE_T_PACK_SIZE = 4;
+static const size_t sxbp_Line_PACK_SIZE = 4;
 
 // private, returns the size in bytes needed to serialise a figure
-static size_t sxbp_get_figure_serialised_size(const sxbp_figure_t* figure) {
-    return SXBP_FILE_HEADER_SIZE + SXBP_LINE_T_PACK_SIZE * figure->size;
+static size_t sxbp_get_figure_serialised_size(const sxbp_Figure* figure) {
+    return SXBP_FILE_HEADER_SIZE + sxbp_Line_PACK_SIZE * figure->size;
 }
 
 /*
@@ -52,7 +52,7 @@ static size_t sxbp_get_figure_serialised_size(const sxbp_figure_t* figure) {
  * - That buffer->bytes is not NULL
  */
 static void sxbp_dump_uint16_t(
-    uint16_t value, sxbp_buffer_t* buffer, size_t* start_index
+    uint16_t value, sxbp_Buffer* buffer, size_t* start_index
 ) {
     // preconditional assertions
     assert(buffer->bytes != NULL);
@@ -73,7 +73,7 @@ static void sxbp_dump_uint16_t(
  * - That buffer->bytes is not NULL
  */
 static void sxbp_dump_uint32_t(
-    uint32_t value, sxbp_buffer_t* buffer, size_t* start_index
+    uint32_t value, sxbp_Buffer* buffer, size_t* start_index
 ) {
     // preconditional assertions
     assert(buffer->bytes != NULL);
@@ -91,8 +91,8 @@ static void sxbp_dump_uint32_t(
 
 // private, writes the header of a serialised figure to a buffer
 static void sxbp_write_sxbp_data_header(
-    const sxbp_figure_t* figure,
-    sxbp_buffer_t* buffer,
+    const sxbp_Figure* figure,
+    sxbp_Buffer* buffer,
     size_t* index
 ) {
     // write the magic number
@@ -124,8 +124,8 @@ static void sxbp_write_sxbp_data_header(
 
 // private, writes one line in serialised form to a buffer
 static void sxbp_write_sxbp_data_line(
-    const sxbp_line_t line,
-    sxbp_buffer_t* buffer,
+    const sxbp_Line line,
+    sxbp_Buffer* buffer,
     size_t* start_index
 ) {
     size_t index = *start_index;
@@ -146,11 +146,11 @@ static void sxbp_write_sxbp_data_line(
 
 // private, writes the body of a serialised figure to a buffer
 static void sxbp_write_sxbp_data_body(
-    const sxbp_figure_t* figure,
-    sxbp_buffer_t* buffer,
+    const sxbp_Figure* figure,
+    sxbp_Buffer* buffer,
     size_t* index
 ) {
-    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
+    for (sxbp_FigureSize i = 0; i < figure->size; i++) {
         sxbp_write_sxbp_data_line(figure->lines[i], buffer, index);
     }
 }
@@ -163,7 +163,7 @@ static void sxbp_write_sxbp_data_body(
  * - That buffer->bytes is not NULL
  */
 static uint16_t sxbp_load_uint16_t(
-    const sxbp_buffer_t* buffer,
+    const sxbp_Buffer* buffer,
     size_t* start_index
 ) {
     // preconditional assertions
@@ -187,7 +187,7 @@ static uint16_t sxbp_load_uint16_t(
  * - That buffer->bytes is not NULL
  */
 static uint32_t sxbp_load_uint32_t(
-    const sxbp_buffer_t* buffer,
+    const sxbp_Buffer* buffer,
     size_t* start_index
 ) {
     // preconditional assertions
@@ -204,17 +204,17 @@ static uint32_t sxbp_load_uint32_t(
 }
 
 // private, checks that the version of the data in the buffer is compatible
-static bool sxbp_check_sxbp_data_version(const sxbp_buffer_t* buffer) {
+static bool sxbp_check_sxbp_data_version(const sxbp_Buffer* buffer) {
     // the version number is encoded starting at index 4 into the file
     size_t index = 4;
     // extract file version from header
-    sxbp_version_t buffer_version = {
+    sxbp_Version buffer_version = {
         .major = sxbp_load_uint16_t(buffer, &index),
         .minor = sxbp_load_uint16_t(buffer, &index),
         .patch = sxbp_load_uint16_t(buffer, &index),
     };
     // this is the minimum version supported by this version of sxbp
-    sxbp_version_t min_version = { .major = 0, .minor = 54, .patch = 0, };
+    sxbp_Version min_version = { .major = 0, .minor = 54, .patch = 0, };
     // compare the extracted version with the minimum one
     return (
         buffer_version.major == min_version.major &&
@@ -223,7 +223,7 @@ static bool sxbp_check_sxbp_data_version(const sxbp_buffer_t* buffer) {
 }
 
 // private, checks if the data in given buffer is a valid serialised sxbp figure
-static bool sxbp_check_sxbp_data_is_valid(const sxbp_buffer_t* buffer) {
+static bool sxbp_check_sxbp_data_is_valid(const sxbp_Buffer* buffer) {
     /*
      * first, check if the file is big enough to contain the header
      * if it is, then check the magic number
@@ -242,8 +242,8 @@ static bool sxbp_check_sxbp_data_is_valid(const sxbp_buffer_t* buffer) {
 
 // private, extracts one line from a data buffer to a line object
 static void sxbp_read_sxbp_data_line(
-    const sxbp_buffer_t* buffer,
-    sxbp_line_t* line,
+    const sxbp_Buffer* buffer,
+    sxbp_Line* line,
     size_t* start_index
 ) {
     size_t index = *start_index;
@@ -270,18 +270,18 @@ static void sxbp_read_sxbp_data_line(
 
 // private, reads in serialised figure lines from a buffer to a figure
 static void sxbp_read_sxbp_data_body(
-    const sxbp_buffer_t* buffer,
-    sxbp_figure_t* figure,
+    const sxbp_Buffer* buffer,
+    sxbp_Figure* figure,
     size_t* index
 ) {
-    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
+    for (sxbp_FigureSize i = 0; i < figure->size; i++) {
         sxbp_read_sxbp_data_line(buffer, &figure->lines[i], index);
     }
 }
 
-sxbp_result_t sxbp_dump_figure(
-    const sxbp_figure_t* figure,
-    sxbp_buffer_t* buffer
+sxbp_Result sxbp_dump_figure(
+    const sxbp_Figure* figure,
+    sxbp_Buffer* buffer
 ) {
     // figure and buffer must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(figure);
@@ -306,9 +306,9 @@ sxbp_result_t sxbp_dump_figure(
     }
 }
 
-sxbp_result_t sxbp_load_figure(
-    const sxbp_buffer_t* buffer,
-    sxbp_figure_t* figure
+sxbp_Result sxbp_load_figure(
+    const sxbp_Buffer* buffer,
+    sxbp_Figure* figure
 ) {
     // buffer and figure must not be NULL
     SXBP_RETURN_FAIL_IF_NULL(buffer);

--- a/sxbp/sxbp.c
+++ b/sxbp/sxbp.c
@@ -20,7 +20,7 @@
 #endif
 
 // Version numbers are passed as preprocessor definitions by CMake
-const sxbp_version_t SXBP_VERSION = {
+const sxbp_Version SXBP_VERSION = {
     .major = SXBP_VERSION_MAJOR,
     .minor = SXBP_VERSION_MINOR,
     .patch = SXBP_VERSION_PATCH,
@@ -29,9 +29,9 @@ const sxbp_version_t SXBP_VERSION = {
 
 const size_t SXBP_BEGIN_BUFFER_MAX_SIZE = 1073741823;
 
-const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT = {
+const sxbp_BeginFigureOptions SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT = {
     .max_lines = 0,
 };
 
-const sxbp_refine_method_t SXBP_REFINE_METHOD_DEFAULT =
+const sxbp_RefineMethod SXBP_REFINE_METHOD_DEFAULT =
     SXBP_REFINE_METHOD_SHRINK_FROM_END;

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -250,7 +250,7 @@ typedef enum sxbp_Result {
  * @todo Try and use Doxygen's `at-param` syntax to document the arguments and
  * use `at-returns` to document the return details.
  */
-typedef sxbp_Result(* sxbp_figure_renderer_t)(
+typedef sxbp_Result(* sxbp_FigureRenderer)(
     const sxbp_Figure* const figure,
     sxbp_Buffer* const buffer,
     const sxbp_RenderOptions* const render_options,
@@ -416,7 +416,7 @@ sxbp_Result sxbp_buffer_from_file(
  * `NULL`
  * @since v0.54.0
  */
-sxbp_Result sxbp_Buffero_file(
+sxbp_Result sxbp_buffer_to_file(
     const sxbp_Buffer* const buffer,
     FILE* file_handle
 );
@@ -699,7 +699,7 @@ sxbp_Result sxbp_render_figure_to_bitmap(
 sxbp_Result sxbp_render_figure(
     const sxbp_Figure* const figure,
     sxbp_Buffer* const buffer,
-    sxbp_figure_renderer_t render_callback,
+    sxbp_FigureRenderer render_callback,
     const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 );

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -37,7 +37,7 @@ extern "C" {
  * @details Versions are of the format <MAJOR.MINOR.patch>
  * @since v0.27.0
  */
-typedef struct sxbp_version_t {
+typedef struct sxbp_Version {
     /** @brief The major version number of the version */
     uint16_t major;
     /** @brief The minor version number of the version */
@@ -46,30 +46,30 @@ typedef struct sxbp_version_t {
     uint16_t patch;
     /** @brief String form of the version (vX.Y.Z) */
     const char* string;
-} sxbp_version_t;
+} sxbp_Version;
 
 /**
  * @brief A simple buffer type for storing arrays of bytes.
  * @since v0.27.0
  */
-typedef struct sxbp_buffer_t {
+typedef struct sxbp_Buffer {
     /** @brief pointer to array of bytes */
     uint8_t* bytes;
     /** @brief the size of the array of bytes */
     size_t size;
-} sxbp_buffer_t;
+} sxbp_Buffer;
 
 /**
  * @brief Type for representing one of the cartesian directions.
  * @since v0.54.0
  * @todo Prefix these constants with `SXBP_DIRECTION_`
  */
-typedef enum sxbp_direction_t {
+typedef enum sxbp_Direction {
     SXBP_UP = 0u, /**< The cartesian direction 'UP' */
     SXBP_RIGHT = 1u, /**< The cartesian direction 'RIGHT' */
     SXBP_DOWN = 2u, /**< The cartesian direction 'DOWN' */
     SXBP_LEFT = 3u, /**< The cartesian direction 'LEFT' */
-} sxbp_direction_t;
+} sxbp_Direction;
 
 /**
  * @brief Type for representing the length of a line segment of a spiral.
@@ -78,7 +78,7 @@ typedef enum sxbp_direction_t {
  * bitfield field with 30 bits allocated to it.
  * @since v0.27.0
  */
-typedef uint32_t sxbp_length_t;
+typedef uint32_t sxbp_Length;
 
 /**
  * @brief Type for representing the size of an SXBP figure
@@ -86,7 +86,7 @@ typedef uint32_t sxbp_length_t;
  * the figure.
  * @since v0.54.0
  */
-typedef uint32_t sxbp_figure_size_t;
+typedef uint32_t sxbp_FigureSize;
 
 /**
  * @brief Represents one line segment in the spiral structure.
@@ -95,23 +95,23 @@ typedef uint32_t sxbp_figure_size_t;
  * @note The whole struct uses bitfields to occupy 32 bits of memory.
  * @since v0.27.0
  */
-typedef struct sxbp_line_t {
+typedef struct sxbp_Line {
     /** @brief uses 2 bits as there's only 4 directions */
-    sxbp_direction_t direction : 2;
+    sxbp_Direction direction : 2;
     /** @brief uses 30 bits for the length, this is wide enough */
-    sxbp_length_t length : 30;
-} sxbp_line_t;
+    sxbp_Length length : 30;
+} sxbp_Line;
 
 /**
  * @brief A structure representing an SXBP 'spiral' figure
  * @details The figure can be in any state of completion or non-completion
  * @since v0.54.0
  */
-typedef struct sxbp_figure_t {
+typedef struct sxbp_Figure {
     /** @brief The total number of lines in the figure */
-    sxbp_figure_size_t size;
+    sxbp_FigureSize size;
     /** @brief The lines that make up the figure */
-    sxbp_line_t* lines;
+    sxbp_Line* lines;
     /**
      * @brief The number of unsolved lines that are remaining
      * @details A line that has not been 'solved' is a line that hasn't been
@@ -119,14 +119,14 @@ typedef struct sxbp_figure_t {
      * @note While this is greater than zero, it is the index of the next line
      * that needs solving
      */
-    sxbp_figure_size_t lines_remaining;
-} sxbp_figure_t;
+    sxbp_FigureSize lines_remaining;
+} sxbp_Figure;
 
 /**
  * @brief A structure used for providing options to `sxbp_begin_figure()`
  * @since v0.54.0
  */
-typedef struct sxbp_begin_figure_options_t {
+typedef struct sxbp_BeginFigureOptions {
     /**
      * @brief The maximum number of lines to create in the figure
      * @details If `0`, then the maximum number of lines possible (based on the
@@ -134,8 +134,8 @@ typedef struct sxbp_begin_figure_options_t {
      * @note If this is greater than the maximum number of lines possible, then
      * the latter is used.
      */
-    sxbp_figure_size_t max_lines;
-} sxbp_begin_figure_options_t;
+    sxbp_FigureSize max_lines;
+} sxbp_BeginFigureOptions;
 
 /**
  * @brief Used to specify which figure refinement method should be used
@@ -149,28 +149,28 @@ typedef struct sxbp_begin_figure_options_t {
  * definition has been returned, or that the value is garbage.
  * @since v0.54.0
  */
-typedef enum sxbp_refine_method_t {
+typedef enum sxbp_RefineMethod {
     SXBP_REFINE_METHOD_ANY = 0u, /**< use any method, the default */
     SXBP_REFINE_METHOD_GROW_FROM_START, /**< the original refinement method */
     SXBP_REFINE_METHOD_SHRINK_FROM_END, /**< the current refinement method */
     SXBP_REFINE_METHOD_RESERVED_START = 10u, /**< reserved for future use */
     SXBP_REFINE_METHOD_RESERVED_END = 255u, /**< reserved for future use */
-} sxbp_refine_method_t;
+} sxbp_RefineMethod;
 
 /**
  * @brief A structure used for providing options to `sxbp_refine_figure()`
  * @since v0.54.0
  */
-typedef struct sxbp_refine_figure_options_t {
+typedef struct sxbp_RefineFigureOptions {
     /**
      * @begin The method to be used to refine the figure
      */
-    sxbp_refine_method_t refine_method;
+    sxbp_RefineMethod refine_method;
     /**
      * @brief An optional callback to be called every time a new line is solved.
      */
     void(* progress_callback)(
-        const sxbp_figure_t* const figure,
+        const sxbp_Figure* const figure,
         void* callback_context
     );
     /**
@@ -181,7 +181,7 @@ typedef struct sxbp_refine_figure_options_t {
      * state variables you might need to write out a message, save a file, etc.
      */
     void* callback_context;
-} sxbp_refine_figure_options_t;
+} sxbp_RefineFigureOptions;
 
 /**
  * @brief A structure used for providing options to `sxbp_render_figure()`
@@ -189,10 +189,10 @@ typedef struct sxbp_refine_figure_options_t {
  * alternative colour for the starting dot, etc...
  * @since v0.54.0
  */
-typedef struct sxbp_render_options_t {
+typedef struct sxbp_RenderOptions {
     /** @brief The scale factor to render the image to */
     size_t scale;
-} sxbp_render_options_t;
+} sxbp_RenderOptions;
 
 /**
  * @brief Type for representing the width or height of a rendered SXBP figure
@@ -200,7 +200,7 @@ typedef struct sxbp_render_options_t {
  * rendered images of sxbp figures.
  * @since v0.54.0
  */
-typedef uint32_t sxbp_figure_dimension_t;
+typedef uint32_t sxbp_FigureDimension;
 
 /**
  * @brief Used to represent a basic 1-bit, pure black/white bitmap image.
@@ -208,18 +208,18 @@ typedef uint32_t sxbp_figure_dimension_t;
  * 1-bit pixels which are either black or white.
  * @since v0.54.0
  */
-typedef struct sxbp_bitmap_t {
+typedef struct sxbp_Bitmap {
     /** @brief The width of the bitmap in pixels */
-    sxbp_figure_dimension_t width;
+    sxbp_FigureDimension width;
     /** @brief The height of the bitmap in pixels */
-    sxbp_figure_dimension_t height;
+    sxbp_FigureDimension height;
     /**
      * @brief A 2-dimensional array of pixels.
      * @details false is the background colour, true is the foreground colour
      * (the line colour)
      */
     bool** pixels;
-} sxbp_bitmap_t;
+} sxbp_Bitmap;
 
 /**
  * @brief Used to represent success/failure states for certain functions in SXBP
@@ -232,7 +232,7 @@ typedef struct sxbp_bitmap_t {
  * the value is garbage.
  * @since v0.54.0
  */
-typedef enum sxbp_result_t {
+typedef enum sxbp_Result {
     SXBP_RESULT_UNKNOWN = 0u, /**< unknown, the default */
     SXBP_RESULT_OK, /**< success */
     SXBP_RESULT_FAIL_MEMORY, /**< failure to allocate or reallocate memory */
@@ -241,7 +241,7 @@ typedef enum sxbp_result_t {
     SXBP_RESULT_FAIL_UNIMPLEMENTED, /**< requested action is not implemented */
     SXBP_RESULT_RESERVED_START, /**< reserved for future use */
     SXBP_RESULT_RESERVED_END = 255u, /**< reserved for future use */
-} sxbp_result_t;
+} sxbp_Result;
 
 /**
  * @brief A convenience typedef for a callback function that renders a figure
@@ -250,10 +250,10 @@ typedef enum sxbp_result_t {
  * @todo Try and use Doxygen's `at-param` syntax to document the arguments and
  * use `at-returns` to document the return details.
  */
-typedef sxbp_result_t(* sxbp_figure_renderer_t)(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+typedef sxbp_Result(* sxbp_figure_renderer_t)(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 );
 
@@ -261,7 +261,7 @@ typedef sxbp_result_t(* sxbp_figure_renderer_t)(
  * @brief Stores the current version of sxbp.
  * @since v0.27.0
  */
-extern const sxbp_version_t SXBP_VERSION;
+extern const sxbp_Version SXBP_VERSION;
 
 /**
  * @brief The maximum size of buffer that can be used to begin a figure
@@ -276,46 +276,46 @@ extern const size_t SXBP_BEGIN_BUFFER_MAX_SIZE;
 /**
  * @brief The default options used for `sxbp_begin_figure()`
  */
-extern const sxbp_begin_figure_options_t SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;
+extern const sxbp_BeginFigureOptions SXBP_BEGIN_FIGURE_OPTIONS_DEFAULT;
 
 /**
  * @brief The default figure refinement method used by `sxbp_refine_figure()`
  */
-extern const sxbp_refine_method_t SXBP_REFINE_METHOD_DEFAULT;
+extern const sxbp_RefineMethod SXBP_REFINE_METHOD_DEFAULT;
 
 /**
- * @brief Returns if a given `sxbp_result_t` is successful or not
+ * @brief Returns if a given `sxbp_Result` is successful or not
  * @details This is intended to be used to easily check the return status of
  * functions in SXBP that can raise errors.
  * @param state The state to check for success/failure
  * @returns `true` if the given status code was success
  * @returns `false` if the given status code was not success
  */
-bool sxbp_success(sxbp_result_t state);
+bool sxbp_success(sxbp_Result state);
 
 /**
- * @brief Checks if a given `sxbp_result_t` is successful or not
+ * @brief Checks if a given `sxbp_Result` is successful or not
  * @details This is intended to be used to easily check the return status of
  * functions in SXBP that can raise errors.
  * @param state The state to check for success/failure
- * @param[out] report_to An optional pointer to a `sxbp_result_t` to store the
+ * @param[out] report_to An optional pointer to a `sxbp_Result` to store the
  * result in, if it was failure. This is ignored if `NULL`.
  * @returns `true` if the given status code was success
  * @returns `false` if the given status code was not success
  */
-bool sxbp_check(sxbp_result_t state, sxbp_result_t* const report_to);
+bool sxbp_check(sxbp_Result state, sxbp_Result* const report_to);
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Creates a blank empty buffer
  * @details Ensures that all pointer fields are properly initialised to NULL
- * @returns An `sxbp_buffer_t` object with all fields set to default/blank value
+ * @returns An `sxbp_Buffer` object with all fields set to default/blank value
  * @since v0.54.0
  */
-sxbp_buffer_t sxbp_blank_buffer(void);
+sxbp_Buffer sxbp_blank_buffer(void);
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Attempts to allocate memory for the bytes of the given buffer
  * @details Attempts to allocate the amount of memory specified by the `size`
  * member of the buffer
@@ -327,10 +327,10 @@ sxbp_buffer_t sxbp_blank_buffer(void);
  * @returns `SXBP_RESULT_FAIL_UNIMPLEMENTED` if `buffer.size` is `0`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer);
+sxbp_Result sxbp_init_buffer(sxbp_Buffer* const buffer);
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Attempts to resize the given buffer
  * @details The buffer will be grown or shrunk depending on if `size` is bigger
  * than or less than it's existing size. If grown, the bytes beyond the extent
@@ -344,10 +344,10 @@ sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer);
  * `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_resize_buffer(sxbp_buffer_t* const buffer, size_t size);
+sxbp_Result sxbp_resize_buffer(sxbp_Buffer* const buffer, size_t size);
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Deallocates any allocated memory for the bytes of the given buffer
  * @note It is safe to call this function multiple times on the same buffer
  * @warning It is unsafe to call this function on a buffer that has been
@@ -357,10 +357,10 @@ sxbp_result_t sxbp_resize_buffer(sxbp_buffer_t* const buffer, size_t size);
  * error condition)
  * @since v0.54.0
  */
-bool sxbp_free_buffer(sxbp_buffer_t* const buffer);
+bool sxbp_free_buffer(sxbp_Buffer* const buffer);
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Attempts to copy one buffer to another
  * @details All the data is copied from the buffer such that both are entirely
  * separate at the completion of the operation. Any data in the `to` buffer
@@ -380,13 +380,13 @@ bool sxbp_free_buffer(sxbp_buffer_t* const buffer);
  * not return an error code.
  * @since v0.54.0
  */
-sxbp_result_t sxbp_copy_buffer(
-    const sxbp_buffer_t* const from,
-    sxbp_buffer_t* const to
+sxbp_Result sxbp_copy_buffer(
+    const sxbp_Buffer* const from,
+    sxbp_Buffer* const to
 );
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Attempts to read the contents of the given file into the given buffer
  * @details Allocates the buffer and copies all the bytes of the file into it
  * @warning The file should have been opened in `rb` mode
@@ -398,13 +398,13 @@ sxbp_result_t sxbp_copy_buffer(
  * `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_buffer_from_file(
+sxbp_Result sxbp_buffer_from_file(
     FILE* file_handle,
-    sxbp_buffer_t* const buffer
+    sxbp_Buffer* const buffer
 );
 
 /**
- * @relatesalso sxbp_buffer_t
+ * @relatesalso sxbp_Buffer
  * @brief Attempts to write the contents of the given buffer to the given file
  * @details Writes all the bytes in the buffer out to the open file
  * @warning The file should have been opened in `wb` mode
@@ -416,22 +416,22 @@ sxbp_result_t sxbp_buffer_from_file(
  * `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_buffer_to_file(
-    const sxbp_buffer_t* const buffer,
+sxbp_Result sxbp_Buffero_file(
+    const sxbp_Buffer* const buffer,
     FILE* file_handle
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Creates a blank empty figure
  * @details Ensures that all pointer fields are properly initialised to NULL
- * @returns An `sxbp_figure_t` object with all fields set to default/blank value
+ * @returns An `sxbp_Figure` object with all fields set to default/blank value
  * @since v0.54.0
  */
-sxbp_figure_t sxbp_blank_figure(void);
+sxbp_Figure sxbp_blank_figure(void);
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Attempts to allocate memory for dynamic members of the given figure
  * @details Attempts to allocate the number of lines specified by the `size`
  * member of the figure, and memory for other private fields of the structure
@@ -445,10 +445,10 @@ sxbp_figure_t sxbp_blank_figure(void);
  * @returns `SXBP_RESULT_FAIL_UNIMPLEMENTED` if `figure.size` is `0`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure);
+sxbp_Result sxbp_init_figure(sxbp_Figure* const figure);
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Deallocates any allocated memory for the given figure
  * @note It is safe to call this function multiple times on the same figure
  * @warning It is unsafe to call this function on a figure that has had any
@@ -459,10 +459,10 @@ sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure);
  * condition)
  * @since v0.54.0
  */
-bool sxbp_free_figure(sxbp_figure_t* const figure);
+bool sxbp_free_figure(sxbp_Figure* const figure);
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Attempts to copy one figure to another
  * @details All the data is copied from the figure such that both are entirely
  * separate at the completion of the operation. Any data in the `to` figure
@@ -483,22 +483,22 @@ bool sxbp_free_figure(sxbp_figure_t* const figure);
  * dynamic memory allocation will still be copied across.
  * @since v0.54.0
  */
-sxbp_result_t sxbp_copy_figure(
-    const sxbp_figure_t* const from,
-    sxbp_figure_t* const to
+sxbp_Result sxbp_copy_figure(
+    const sxbp_Figure* const from,
+    sxbp_Figure* const to
 );
 
 /**
- * @relatesalso sxbp_bitmap_t
+ * @relatesalso sxbp_Bitmap
  * @brief Creates a blank empty bitmap
  * @details Ensures that all pointer fields are properly initialised to NULL
- * @returns An `sxbp_bitmap_t` object with all fields set to default/blank value
+ * @returns An `sxbp_Bitmap` object with all fields set to default/blank value
  * @since v0.54.0
  */
-sxbp_bitmap_t sxbp_blank_bitmap(void);
+sxbp_Bitmap sxbp_blank_bitmap(void);
 
 /**
- * @relatesalso sxbp_bitmap_t
+ * @relatesalso sxbp_Bitmap
  * @brief Attempts to allocate memory for the pixels of the given bitmap
  * @details Attempts to allocate the memory for the amount of pixels specified
  * by the `width` and `height` members of the bitmap
@@ -510,10 +510,10 @@ sxbp_bitmap_t sxbp_blank_bitmap(void);
  * @returns `SXBP_RESULT_FAIL_UNIMPLEMENTED` if `bitmap.width` or `bitmap.height` are `0`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap);
+sxbp_Result sxbp_init_bitmap(sxbp_Bitmap* const bitmap);
 
 /**
- * @relatesalso sxbp_bitmap_t
+ * @relatesalso sxbp_Bitmap
  * @brief Deallocates any allocated memory for the pixels of the given bitmap
  * @note It is safe to call this function multiple times on the same bitmap
  * @warning It is unsafe to call this function on a bitmap that has been
@@ -523,10 +523,10 @@ sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap);
  * error condition)
  * @since v0.54.0
  */
-bool sxbp_free_bitmap(sxbp_bitmap_t* const bitmap);
+bool sxbp_free_bitmap(sxbp_Bitmap* const bitmap);
 
 /**
- * @relatesalso sxbp_bitmap_t
+ * @relatesalso sxbp_Bitmap
  * @brief Attempts to copy one bitmap to another
  * @details All the data is copied from the bitmap such that both are entirely
  * separate at the completion of the operation. Any data in the `to` bitmap
@@ -548,13 +548,13 @@ bool sxbp_free_bitmap(sxbp_bitmap_t* const bitmap);
  * still be copied across.
  * @since v0.54.0
  */
-sxbp_result_t sxbp_copy_bitmap(
-    const sxbp_bitmap_t* const from,
-    sxbp_bitmap_t* const to
+sxbp_Result sxbp_copy_bitmap(
+    const sxbp_Bitmap* const from,
+    sxbp_Bitmap* const to
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Converts the given binary data into an early-draft SXBP figure
  * @details The data in the given buffer is converted into a sequence of spiral
  * directions and from these an unrefined rudimentary line is plotted in the
@@ -577,14 +577,14 @@ sxbp_result_t sxbp_copy_bitmap(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `data` or `figure` is `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_begin_figure(
-    const sxbp_buffer_t* const data,
-    const sxbp_begin_figure_options_t* const options,
-    sxbp_figure_t* const figure
+sxbp_Result sxbp_begin_figure(
+    const sxbp_Buffer* const data,
+    const sxbp_BeginFigureOptions* const options,
+    sxbp_Figure* const figure
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Refines the line lengths of the given SXBP figure
  * @details The line lengths are adjusted to take up less space than that
  * which are generated by `sxbp_begin_figure`
@@ -604,13 +604,13 @@ sxbp_result_t sxbp_begin_figure(
  * refining the figure
  * @since v0.54.0
  */
-sxbp_result_t sxbp_refine_figure(
-    sxbp_figure_t* const figure,
-    const sxbp_refine_figure_options_t* const options
+sxbp_Result sxbp_refine_figure(
+    sxbp_Figure* const figure,
+    const sxbp_RefineFigureOptions* const options
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Serialises the given figure to data, stored in the given buffer
  * @details The buffer is populated with bytes which represent the figure and
  * from whch compatible versions of SXBP can load figures from again
@@ -623,13 +623,13 @@ sxbp_result_t sxbp_refine_figure(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `buffer` is `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_dump_figure(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer
+sxbp_Result sxbp_dump_figure(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Attempts to deserialise an SXBP figure from the given buffer
  * @details A serialised SXBP figure is extracted from the buffer's data to the
  * given figure, if the buffer data is valid, containing an SXBP figure in the
@@ -646,13 +646,13 @@ sxbp_result_t sxbp_dump_figure(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `buffer` or `figure` is `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_load_figure(
-    const sxbp_buffer_t* const buffer,
-    sxbp_figure_t* const figure
+sxbp_Result sxbp_load_figure(
+    const sxbp_Buffer* const buffer,
+    sxbp_Figure* const figure
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Rasterises an image of the given figure to a basic bitmap object
  * @details A 1-bit black/white bitmap image of the line formed by the SXBP
  * figure is rendered to the given bitmap object
@@ -665,13 +665,13 @@ sxbp_result_t sxbp_load_figure(
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure` or `bitmap` is `NULL`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_render_figure_to_bitmap(
-    const sxbp_figure_t* const figure,
-    sxbp_bitmap_t* const bitmap
+sxbp_Result sxbp_render_figure_to_bitmap(
+    const sxbp_Figure* const figure,
+    sxbp_Bitmap* const bitmap
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Renders an image of the given figure, using the given render callback
  * @details The render callback should write out the bytes of the rendered image
  * to the given buffer.
@@ -692,20 +692,20 @@ sxbp_result_t sxbp_render_figure_to_bitmap(
  * @returns `SXBP_RESULT_OK` if the figure could be rendered successfully
  * @returns `SXBP_RESULT_FAIL_PRECONDITION` if `figure`, `buffer` or
  * `render_callback` are `NULL`
- * @returns Any other valid value for type `sxbp_result_t`, according to all
+ * @returns Any other valid value for type `sxbp_Result`, according to all
  * the possible error codes that can be returned by the given render callback.
  * @since v0.54.0
  */
-sxbp_result_t sxbp_render_figure(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
+sxbp_Result sxbp_render_figure(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
     sxbp_figure_renderer_t render_callback,
-    const sxbp_render_options_t* const render_options,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief A dummy renderer function that does nothing
  * @details This exists for testing purposes only
  * @warn This function is currently unusable because it always returns the
@@ -713,15 +713,15 @@ sxbp_result_t sxbp_render_figure(
  * @returns `SXBP_RESULT_FAIL_UNIMPLEMENTED`
  * @since v0.54.0
  */
-sxbp_result_t sxbp_render_figure_to_null(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+sxbp_Result sxbp_render_figure_to_null(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Renders figures to PBM images
  * @details If successful, the buffer will be filled with data which represents
  * a binary format PBM image (P4 format).
@@ -730,15 +730,15 @@ sxbp_result_t sxbp_render_figure_to_null(
  * @returns `SXBP_RESULT_FAIL_MEMORY` if a memory allocation error occurred
  * @since v0.54.0
  */
-sxbp_result_t sxbp_render_figure_to_pbm(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+sxbp_Result sxbp_render_figure_to_pbm(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 );
 
 /**
- * @relatesalso sxbp_figure_t
+ * @relatesalso sxbp_Figure
  * @brief Renders figures to SVG images
  * @details If successful, the buffer will be filled with data which represents
  * an SVG image.
@@ -747,10 +747,10 @@ sxbp_result_t sxbp_render_figure_to_pbm(
  * @returns `SXBP_RESULT_FAIL_MEMORY` if a memory allocation error occurred
  * @since v0.54.0
  */
-sxbp_result_t sxbp_render_figure_to_svg(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+sxbp_Result sxbp_render_figure_to_svg(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 );
 

--- a/sxbp/sxbp.h
+++ b/sxbp/sxbp.h
@@ -74,7 +74,7 @@ typedef enum sxbp_Direction {
 /**
  * @brief Type for representing the length of a line segment of a spiral.
  * @note Although the width of this type is 32 bits, it is actually only 30 bits
- * when used in the sxbp_spiral_t struct type. This is because here it is a
+ * when used in the sxbp_Figure struct type. This is because here it is a
  * bitfield field with 30 bits allocated to it.
  * @since v0.27.0
  */

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -32,14 +32,14 @@
 #error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
-const sxbp_vector_t SXBP_VECTOR_DIRECTIONS[4] = {
+const sxbp_Vector SXBP_VECTOR_DIRECTIONS[4] = {
     [SXBP_UP]    = {  0,  1, },
     [SXBP_RIGHT] = {  1,  0, },
     [SXBP_DOWN]  = {  0, -1, },
     [SXBP_LEFT]  = { -1,  0, },
 };
 
-void sxbp_update_bounds(sxbp_co_ord_t location, sxbp_bounds_t* bounds) {
+void sxbp_update_bounds(sxbp_CoOrd location, sxbp_Bounds* bounds) {
     // preconditional assertions
     assert(bounds != NULL);
     if (location.x > bounds->x_max) {
@@ -55,19 +55,19 @@ void sxbp_update_bounds(sxbp_co_ord_t location, sxbp_bounds_t* bounds) {
 }
 
 void sxbp_move_location(
-    sxbp_co_ord_t* location,
+    sxbp_CoOrd* location,
     sxbp_Direction direction,
     sxbp_Length length
 ) {
     // preconditional assertions
     assert(location != NULL);
-    sxbp_vector_t vector = SXBP_VECTOR_DIRECTIONS[direction];
-    location->x += vector.x * (sxbp_tuple_item_t)length;
-    location->y += vector.y * (sxbp_tuple_item_t)length;
+    sxbp_Vector vector = SXBP_VECTOR_DIRECTIONS[direction];
+    location->x += vector.x * (sxbp_TupleItem)length;
+    location->y += vector.y * (sxbp_TupleItem)length;
 }
 
 void sxbp_move_location_along_line(
-    sxbp_co_ord_t* location,
+    sxbp_CoOrd* location,
     sxbp_Line line
 ) {
     // preconditional assertions
@@ -75,12 +75,12 @@ void sxbp_move_location_along_line(
     sxbp_move_location(location, line.direction, line.length);
 }
 
-sxbp_bounds_t sxbp_get_bounds(const sxbp_Figure* figure, size_t scale) {
+sxbp_Bounds sxbp_get_bounds(const sxbp_Figure* figure, size_t scale) {
     // preconditional assertions
     assert(figure != NULL);
     // loop state variables
-    sxbp_co_ord_t location = { 0 }; // where the end of the last line is
-    sxbp_bounds_t bounds = { 0 }; // the bounds of the line walked so far
+    sxbp_CoOrd location = { 0 }; // where the end of the last line is
+    sxbp_Bounds bounds = { 0 }; // the bounds of the line walked so far
     // walk the line!
     for (sxbp_FigureSize i = 0; i < figure->size; i++) {
         // update the location, scaling in proportion to scale
@@ -96,14 +96,14 @@ sxbp_bounds_t sxbp_get_bounds(const sxbp_Figure* figure, size_t scale) {
     return bounds;
 }
 
-sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds) {
+sxbp_CoOrd sxbp_get_origin_from_bounds(const sxbp_Bounds bounds) {
     /*
      * the origin (also known as the transformation vector) for all coördinates
      * is the negative of the minimum bounds of the line
      * starting the line at this non-negative point ensures that all coördinates
      * of the line are positive
      */
-    return (sxbp_co_ord_t){
+    return (sxbp_CoOrd){
         .x = -bounds.x_min,
         .y = -bounds.y_min,
     };
@@ -113,16 +113,16 @@ void sxbp_walk_figure(
     const sxbp_Figure* figure,
     size_t scale,
     bool plot_vertices_only,
-    bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
+    bool( *plot_point_callback)(sxbp_CoOrd location, void* callback_data),
     void* callback_data
 ) {
     // preconditional assertions
     assert(figure != NULL);
     assert(plot_point_callback != NULL);
     // get figure's bounds
-    sxbp_bounds_t bounds = sxbp_get_bounds(figure, scale);
+    sxbp_Bounds bounds = sxbp_get_bounds(figure, scale);
     // start the line at the origin
-    sxbp_co_ord_t location = sxbp_get_origin_from_bounds(bounds);
+    sxbp_CoOrd location = sxbp_get_origin_from_bounds(bounds);
     // plot the first point of the line, if callback returned false then exit
     if (!plot_point_callback(location, callback_data)) {
         return;
@@ -154,7 +154,7 @@ void sxbp_walk_figure(
 }
 
 void sxbp_get_size_from_bounds(
-    const sxbp_bounds_t bounds,
+    const sxbp_Bounds bounds,
     sxbp_FigureDimension* restrict width,
     sxbp_FigureDimension* restrict height
 ) {
@@ -194,7 +194,7 @@ bool sxbp_dimension_to_string(
 }
 
 sxbp_Result sxbp_make_bitmap_for_bounds(
-    const sxbp_bounds_t bounds,
+    const sxbp_Bounds bounds,
     sxbp_Bitmap* bitmap
 ) {
     // preconditional assertions

--- a/sxbp/sxbp_internal.c
+++ b/sxbp/sxbp_internal.c
@@ -56,8 +56,8 @@ void sxbp_update_bounds(sxbp_co_ord_t location, sxbp_bounds_t* bounds) {
 
 void sxbp_move_location(
     sxbp_co_ord_t* location,
-    sxbp_direction_t direction,
-    sxbp_length_t length
+    sxbp_Direction direction,
+    sxbp_Length length
 ) {
     // preconditional assertions
     assert(location != NULL);
@@ -68,21 +68,21 @@ void sxbp_move_location(
 
 void sxbp_move_location_along_line(
     sxbp_co_ord_t* location,
-    sxbp_line_t line
+    sxbp_Line line
 ) {
     // preconditional assertions
     assert(location != NULL);
     sxbp_move_location(location, line.direction, line.length);
 }
 
-sxbp_bounds_t sxbp_get_bounds(const sxbp_figure_t* figure, size_t scale) {
+sxbp_bounds_t sxbp_get_bounds(const sxbp_Figure* figure, size_t scale) {
     // preconditional assertions
     assert(figure != NULL);
     // loop state variables
     sxbp_co_ord_t location = { 0 }; // where the end of the last line is
     sxbp_bounds_t bounds = { 0 }; // the bounds of the line walked so far
     // walk the line!
-    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
+    for (sxbp_FigureSize i = 0; i < figure->size; i++) {
         // update the location, scaling in proportion to scale
         sxbp_move_location(
             &location,
@@ -110,7 +110,7 @@ sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds) {
 }
 
 void sxbp_walk_figure(
-    const sxbp_figure_t* figure,
+    const sxbp_Figure* figure,
     size_t scale,
     bool plot_vertices_only,
     bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
@@ -128,10 +128,10 @@ void sxbp_walk_figure(
         return;
     }
     // for each line, plot one or more points along it (depending on plot mode)
-    for (sxbp_figure_size_t i = 0; i < figure->size; i++) {
-        sxbp_line_t line = figure->lines[i];
+    for (sxbp_FigureSize i = 0; i < figure->size; i++) {
+        sxbp_Line line = figure->lines[i];
         // scale the line's size
-        sxbp_length_t length = line.length * scale;
+        sxbp_Length length = line.length * scale;
         // if plotting vertices only, plot one point at the end of this line
         if (plot_vertices_only) {
             // move the location length amount of units
@@ -141,7 +141,7 @@ void sxbp_walk_figure(
                 return;
             }
         } else { // otherwise, plot one point along each one unit of line length
-            for (sxbp_length_t l = 0; l < length; l++) {
+            for (sxbp_Length l = 0; l < length; l++) {
                 // move the location one unit
                 sxbp_move_location(&location, line.direction, 1);
                 // plot a point, if callback returned false then exit
@@ -155,8 +155,8 @@ void sxbp_walk_figure(
 
 void sxbp_get_size_from_bounds(
     const sxbp_bounds_t bounds,
-    sxbp_figure_dimension_t* restrict width,
-    sxbp_figure_dimension_t* restrict height
+    sxbp_FigureDimension* restrict width,
+    sxbp_FigureDimension* restrict height
 ) {
     // pointer arguments must not be NULL!
     assert(width != NULL);
@@ -167,12 +167,12 @@ void sxbp_get_size_from_bounds(
      * this makes sense because for example from 1 to 10 there are 10 values
      * and the difference of these is 9 so the number of values is 9+1 = 10
      */
-    *width = (sxbp_figure_dimension_t)((bounds.x_max - bounds.x_min) + 1);
-    *height = (sxbp_figure_dimension_t)((bounds.y_max - bounds.y_min) + 1);
+    *width = (sxbp_FigureDimension)((bounds.x_max - bounds.x_min) + 1);
+    *height = (sxbp_FigureDimension)((bounds.y_max - bounds.y_min) + 1);
 }
 
 bool sxbp_dimension_to_string(
-    sxbp_figure_dimension_t dimension,
+    sxbp_FigureDimension dimension,
     char(* output_string)[11],
     size_t* string_length
 ) {
@@ -193,9 +193,9 @@ bool sxbp_dimension_to_string(
     }
 }
 
-sxbp_result_t sxbp_make_bitmap_for_bounds(
+sxbp_Result sxbp_make_bitmap_for_bounds(
     const sxbp_bounds_t bounds,
-    sxbp_bitmap_t* bitmap
+    sxbp_Bitmap* bitmap
 ) {
     // preconditional assertions
     assert(bitmap != NULL);
@@ -206,9 +206,9 @@ sxbp_result_t sxbp_make_bitmap_for_bounds(
     return sxbp_init_bitmap(bitmap);
 }
 
-void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream) {
-    for (sxbp_figure_size_t y = 0; y < bitmap->height; y++) {
-        for (sxbp_figure_size_t x = 0; x < bitmap->width; x++) {
+void sxbp_print_bitmap(sxbp_Bitmap* bitmap, FILE* stream) {
+    for (sxbp_FigureSize y = 0; y < bitmap->height; y++) {
+        for (sxbp_FigureSize x = 0; x < bitmap->width; x++) {
             fprintf(stream, bitmap->pixels[x][y] ? "█" : "░");
         }
         fprintf(stream, "\n");

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -73,15 +73,15 @@ void sxbp_update_bounds(sxbp_co_ord_t location, sxbp_bounds_t* bounds);
 // private, 'move' the given location in the given direction by the given amount
 void sxbp_move_location(
     sxbp_co_ord_t* location,
-    sxbp_direction_t direction,
-    sxbp_length_t length
+    sxbp_Direction direction,
+    sxbp_Length length
 );
 
 // private, 'move' the given location along the given line
-void sxbp_move_location_along_line(sxbp_co_ord_t* location, sxbp_line_t line);
+void sxbp_move_location_along_line(sxbp_co_ord_t* location, sxbp_Line line);
 
 // private, calculates the figure's complete bounds in one step
-sxbp_bounds_t sxbp_get_bounds(const sxbp_figure_t* figure, size_t scale);
+sxbp_bounds_t sxbp_get_bounds(const sxbp_Figure* figure, size_t scale);
 
 /*
  * private, calculates the correct starting coördinates of a line such that
@@ -100,7 +100,7 @@ sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds);
  * walking the line, otherwise it should return true.
  */
 void sxbp_walk_figure(
-    const sxbp_figure_t* figure,
+    const sxbp_Figure* figure,
     size_t scale,
     bool plot_vertices_only,
     bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
@@ -114,8 +114,8 @@ void sxbp_walk_figure(
  */
 void sxbp_get_size_from_bounds(
     const sxbp_bounds_t bounds,
-    sxbp_figure_dimension_t* restrict width,
-    sxbp_figure_dimension_t* restrict height
+    sxbp_FigureDimension* restrict width,
+    sxbp_FigureDimension* restrict height
 );
 
 /*
@@ -125,24 +125,24 @@ void sxbp_get_size_from_bounds(
  * returns true/false for whether the operation succeeded or not
  */
 bool sxbp_dimension_to_string(
-    sxbp_figure_dimension_t dimension,
+    sxbp_FigureDimension dimension,
     char(* output_string)[11],
     size_t* string_length
 );
 
 // private, builds a bitmap large enough to fit coördinates in the given bounds
-sxbp_result_t sxbp_make_bitmap_for_bounds(
+sxbp_Result sxbp_make_bitmap_for_bounds(
     const sxbp_bounds_t bounds,
-    sxbp_bitmap_t* bitmap
+    sxbp_Bitmap* bitmap
 );
 
 // private, prints out a bitmap to the given stream, for debugging
-void sxbp_print_bitmap(sxbp_bitmap_t* bitmap, FILE* stream);
+void sxbp_print_bitmap(sxbp_Bitmap* bitmap, FILE* stream);
 
 // private, refines a figure using the 'shrink from end' method
-sxbp_result_t sxbp_refine_figure_shrink_from_end(
-    sxbp_figure_t* figure,
-    const sxbp_refine_figure_options_t* options
+sxbp_Result sxbp_refine_figure_shrink_from_end(
+    sxbp_Figure* figure,
+    const sxbp_RefineFigureOptions* options
 );
 
 // private, macro to assist in 'return early if NULL pointer' error checks

--- a/sxbp/sxbp_internal.h
+++ b/sxbp/sxbp_internal.h
@@ -37,57 +37,57 @@ extern "C" {
 #endif
 
 // private type for storing one of the items of a tuple
-typedef int32_t sxbp_tuple_item_t;
+typedef int32_t sxbp_TupleItem;
 
 // private generic tuple type for storing a vector-based quantity
-typedef struct sxbp_tuple_t {
-    sxbp_tuple_item_t x; // the x (horizontal) value of the tuple
-    sxbp_tuple_item_t y; // the y (vertical) value of the tuple
-} sxbp_tuple_t;
+typedef struct sxbp_Tuple {
+    sxbp_TupleItem x; // the x (horizontal) value of the tuple
+    sxbp_TupleItem y; // the y (vertical) value of the tuple
+} sxbp_Tuple;
 
 // private vector type used for representing directions
-typedef sxbp_tuple_t sxbp_vector_t;
+typedef sxbp_Tuple sxbp_Vector;
 // private coördinate type used for representing cartesian coördinates
-typedef sxbp_tuple_t sxbp_co_ord_t;
+typedef sxbp_Tuple sxbp_CoOrd;
 
 // private structure for storing figure's bounds (when line is plotted out)
-typedef struct sxbp_bounds_t {
-    sxbp_tuple_item_t x_min; // the smallest value x has been so far
-    sxbp_tuple_item_t x_max; // the largest value x has been so far
-    sxbp_tuple_item_t y_min; // the smallest value y has been so far
-    sxbp_tuple_item_t y_max; // the largest value y has been so far
-} sxbp_bounds_t;
+typedef struct sxbp_Bounds {
+    sxbp_TupleItem x_min; // the smallest value x has been so far
+    sxbp_TupleItem x_max; // the largest value x has been so far
+    sxbp_TupleItem y_min; // the smallest value y has been so far
+    sxbp_TupleItem y_max; // the largest value y has been so far
+} sxbp_Bounds;
 
 /*
  * vector direction constants (private)
  * these can be indexed by the cartesian direction constants
  */
-extern const sxbp_vector_t SXBP_VECTOR_DIRECTIONS[4];
+extern const sxbp_Vector SXBP_VECTOR_DIRECTIONS[4];
 
 /*
  * private, updates the current figure bounds given the location of the end of
  * the most recently-plotted line
  */
-void sxbp_update_bounds(sxbp_co_ord_t location, sxbp_bounds_t* bounds);
+void sxbp_update_bounds(sxbp_CoOrd location, sxbp_Bounds* bounds);
 
 // private, 'move' the given location in the given direction by the given amount
 void sxbp_move_location(
-    sxbp_co_ord_t* location,
+    sxbp_CoOrd* location,
     sxbp_Direction direction,
     sxbp_Length length
 );
 
 // private, 'move' the given location along the given line
-void sxbp_move_location_along_line(sxbp_co_ord_t* location, sxbp_Line line);
+void sxbp_move_location_along_line(sxbp_CoOrd* location, sxbp_Line line);
 
 // private, calculates the figure's complete bounds in one step
-sxbp_bounds_t sxbp_get_bounds(const sxbp_Figure* figure, size_t scale);
+sxbp_Bounds sxbp_get_bounds(const sxbp_Figure* figure, size_t scale);
 
 /*
  * private, calculates the correct starting coördinates of a line such that
  * every coördinate is a positive number from the line's bounds
  */
-sxbp_co_ord_t sxbp_get_origin_from_bounds(const sxbp_bounds_t bounds);
+sxbp_CoOrd sxbp_get_origin_from_bounds(const sxbp_Bounds bounds);
 
 /*
  * private, walks the line of the figure, calling the callback with the
@@ -103,7 +103,7 @@ void sxbp_walk_figure(
     const sxbp_Figure* figure,
     size_t scale,
     bool plot_vertices_only,
-    bool( *plot_point_callback)(sxbp_co_ord_t location, void* callback_data),
+    bool( *plot_point_callback)(sxbp_CoOrd location, void* callback_data),
     void* callback_data
 );
 
@@ -113,7 +113,7 @@ void sxbp_walk_figure(
  * `height`
  */
 void sxbp_get_size_from_bounds(
-    const sxbp_bounds_t bounds,
+    const sxbp_Bounds bounds,
     sxbp_FigureDimension* restrict width,
     sxbp_FigureDimension* restrict height
 );
@@ -132,7 +132,7 @@ bool sxbp_dimension_to_string(
 
 // private, builds a bitmap large enough to fit coördinates in the given bounds
 sxbp_Result sxbp_make_bitmap_for_bounds(
-    const sxbp_bounds_t bounds,
+    const sxbp_Bounds bounds,
     sxbp_Bitmap* bitmap
 );
 

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -26,12 +26,12 @@
 #error "This file is ISO C99. It should not be compiled with a C++ Compiler."
 #endif
 
-bool sxbp_success(sxbp_result_t state) {
+bool sxbp_success(sxbp_Result state) {
     // return whether state was 'OK or not'
     return state == SXBP_RESULT_OK;
 }
 
-bool sxbp_check(sxbp_result_t state, sxbp_result_t* const report_to) {
+bool sxbp_check(sxbp_Result state, sxbp_Result* const report_to) {
     // return true immediately if the state is 'OK'
     if (sxbp_success(state)) {
         return true;
@@ -45,11 +45,11 @@ bool sxbp_check(sxbp_result_t state, sxbp_result_t* const report_to) {
     }
 }
 
-sxbp_buffer_t sxbp_blank_buffer(void) {
-    return (sxbp_buffer_t){ .size = 0, .bytes = NULL, };
+sxbp_Buffer sxbp_blank_buffer(void) {
+    return (sxbp_Buffer){ .size = 0, .bytes = NULL, };
 }
 
-sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer) {
+sxbp_Result sxbp_init_buffer(sxbp_Buffer* const buffer) {
     // check buffer isn't NULL
     SXBP_RETURN_FAIL_IF_NULL(buffer);
     // return failure early if size is 0 --we do not allocate 0 bytes of memory
@@ -62,7 +62,7 @@ sxbp_result_t sxbp_init_buffer(sxbp_buffer_t* const buffer) {
     return buffer->bytes != NULL ? SXBP_RESULT_OK : SXBP_RESULT_FAIL_MEMORY;
 }
 
-sxbp_result_t sxbp_resize_buffer(sxbp_buffer_t* const buffer, size_t size) {
+sxbp_Result sxbp_resize_buffer(sxbp_Buffer* const buffer, size_t size) {
     // check buffer and buffer->bytes aren't NULL
     SXBP_RETURN_FAIL_IF_NULL(buffer);
     SXBP_RETURN_FAIL_IF_NULL(buffer->bytes);
@@ -85,7 +85,7 @@ sxbp_result_t sxbp_resize_buffer(sxbp_buffer_t* const buffer, size_t size) {
     }
 }
 
-bool sxbp_free_buffer(sxbp_buffer_t* const buffer) {
+bool sxbp_free_buffer(sxbp_Buffer* const buffer) {
     // if buffer and bytes are not NULL, assume there's memory to be deallocated
     if (buffer != NULL && buffer->bytes != NULL) {
         free(buffer->bytes);
@@ -98,9 +98,9 @@ bool sxbp_free_buffer(sxbp_buffer_t* const buffer) {
     }
 }
 
-sxbp_result_t sxbp_copy_buffer(
-    const sxbp_buffer_t* const from,
-    sxbp_buffer_t* const to
+sxbp_Result sxbp_copy_buffer(
+    const sxbp_Buffer* const from,
+    sxbp_Buffer* const to
 ) {
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(from);
@@ -150,9 +150,9 @@ static size_t sxbp_get_file_size(FILE* file_handle) {
     return file_size;
 }
 
-sxbp_result_t sxbp_buffer_from_file(
+sxbp_Result sxbp_buffer_from_file(
     FILE* file_handle,
-    sxbp_buffer_t* const buffer
+    sxbp_Buffer* const buffer
 ) {
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(file_handle);
@@ -189,8 +189,8 @@ sxbp_result_t sxbp_buffer_from_file(
     }
 }
 
-sxbp_result_t sxbp_buffer_to_file(
-    const sxbp_buffer_t* const buffer,
+sxbp_Result sxbp_Buffero_file(
+    const sxbp_Buffer* const buffer,
     FILE* file_handle
 ) {
     // check both pointers to ensure they're not NULL
@@ -207,11 +207,11 @@ sxbp_result_t sxbp_buffer_to_file(
     return bytes_written == buffer->size ? SXBP_RESULT_OK : SXBP_RESULT_FAIL_IO;
 }
 
-sxbp_figure_t sxbp_blank_figure(void) {
-    return (sxbp_figure_t){ .size = 0, .lines = NULL, .lines_remaining = 0, };
+sxbp_Figure sxbp_blank_figure(void) {
+    return (sxbp_Figure){ .size = 0, .lines = NULL, .lines_remaining = 0, };
 }
 
-sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure) {
+sxbp_Result sxbp_init_figure(sxbp_Figure* const figure) {
     // check figure isn't NULL
     SXBP_RETURN_FAIL_IF_NULL(figure);
     // return failure early if size is 0 --we do not allocate 0 bytes of memory
@@ -219,12 +219,12 @@ sxbp_result_t sxbp_init_figure(sxbp_figure_t* const figure) {
         return SXBP_RESULT_FAIL_UNIMPLEMENTED;
     }
     // allocate the lines, using calloc to set all fields of each one to zero
-    figure->lines = calloc(figure->size, sizeof(sxbp_line_t));
+    figure->lines = calloc(figure->size, sizeof(sxbp_Line));
     // if lines is not NULL, then the operation was successful
     return figure->lines != NULL ? SXBP_RESULT_OK : SXBP_RESULT_FAIL_MEMORY;
 }
 
-bool sxbp_free_figure(sxbp_figure_t* const figure) {
+bool sxbp_free_figure(sxbp_Figure* const figure) {
     // if figure and lines are not NULL, assume there's memory to be deallocated
     if (figure != NULL && figure->lines != NULL) {
         free(figure->lines);
@@ -237,9 +237,9 @@ bool sxbp_free_figure(sxbp_figure_t* const figure) {
     }
 }
 
-sxbp_result_t sxbp_copy_figure(
-    const sxbp_figure_t* const from,
-    sxbp_figure_t* const to
+sxbp_Result sxbp_copy_figure(
+    const sxbp_Figure* const from,
+    sxbp_Figure* const to
 ) {
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(from);
@@ -270,24 +270,24 @@ sxbp_result_t sxbp_copy_figure(
         return SXBP_RESULT_FAIL_MEMORY;
     } else {
         // allocation succeeded, so now copy the lines
-        memcpy(to->lines, from->lines, to->size * sizeof(sxbp_line_t));
+        memcpy(to->lines, from->lines, to->size * sizeof(sxbp_Line));
         return SXBP_RESULT_OK;
     }
 }
 
-sxbp_bitmap_t sxbp_blank_bitmap(void) {
-    return (sxbp_bitmap_t){ .width = 0, .height = 0, .pixels = NULL, };
+sxbp_Bitmap sxbp_blank_bitmap(void) {
+    return (sxbp_Bitmap){ .width = 0, .height = 0, .pixels = NULL, };
 }
 
 // allocates memory for one column of a bitmap, returning whether it succeeded
-static bool sxbp_init_bitmap_col(bool** col, sxbp_figure_dimension_t size) {
+static bool sxbp_init_bitmap_col(bool** col, sxbp_FigureDimension size) {
     // allocate col with calloc
     *col = calloc(size, sizeof(bool));
     // if col is not NULL, then the operation was successful
     return *col != NULL;
 }
 
-sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap) {
+sxbp_Result sxbp_init_bitmap(sxbp_Bitmap* const bitmap) {
     // check bitmap isn't NULL
     SXBP_RETURN_FAIL_IF_NULL(bitmap);
     /*
@@ -304,7 +304,7 @@ sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap) {
         return SXBP_RESULT_FAIL_MEMORY;
     } else {
         // allocation of col pointers succeeded, now try and allocate each col
-        for (sxbp_figure_dimension_t col = 0; col < bitmap->width; col++) {
+        for (sxbp_FigureDimension col = 0; col < bitmap->width; col++) {
             if (
                 !sxbp_success(
                     sxbp_init_bitmap_col(&bitmap->pixels[col], bitmap->height)
@@ -320,11 +320,11 @@ sxbp_result_t sxbp_init_bitmap(sxbp_bitmap_t* const bitmap) {
     }
 }
 
-bool sxbp_free_bitmap(sxbp_bitmap_t* const bitmap) {
+bool sxbp_free_bitmap(sxbp_Bitmap* const bitmap) {
     // if bitmap and pixels aren't NULL, assume there are cols to be deallocated
     if (bitmap != NULL && bitmap->pixels != NULL) {
         // deallocate each col that needs deallocating first
-        for (sxbp_figure_dimension_t col = 0; col < bitmap->width; col++) {
+        for (sxbp_FigureDimension col = 0; col < bitmap->width; col++) {
             if (bitmap->pixels[col] != NULL) {
                 free(bitmap->pixels[col]);
             }
@@ -338,9 +338,9 @@ bool sxbp_free_bitmap(sxbp_bitmap_t* const bitmap) {
     }
 }
 
-sxbp_result_t sxbp_copy_bitmap(
-    const sxbp_bitmap_t* const from,
-    sxbp_bitmap_t* const to
+sxbp_Result sxbp_copy_bitmap(
+    const sxbp_Bitmap* const from,
+    sxbp_Bitmap* const to
 ) {
     // check both pointers to ensure they're not NULL
     SXBP_RETURN_FAIL_IF_NULL(from);
@@ -371,7 +371,7 @@ sxbp_result_t sxbp_copy_bitmap(
         return SXBP_RESULT_FAIL_MEMORY;
     } else {
         // allocation succeeded, so now copy the pixels
-        for (sxbp_figure_dimension_t col = 0; col < to->width; col++) {
+        for (sxbp_FigureDimension col = 0; col < to->width; col++) {
             memcpy(to->pixels[col], from->pixels[col], to->height);
         }
         return SXBP_RESULT_OK;

--- a/sxbp/utils.c
+++ b/sxbp/utils.c
@@ -189,7 +189,7 @@ sxbp_Result sxbp_buffer_from_file(
     }
 }
 
-sxbp_Result sxbp_Buffero_file(
+sxbp_Result sxbp_buffer_to_file(
     const sxbp_Buffer* const buffer,
     FILE* file_handle
 ) {

--- a/tests/test_bitmap.c
+++ b/tests/test_bitmap.c
@@ -2,7 +2,7 @@
  * This source file forms part of sxbp, a library which generates experimental
  * 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides unit tests for the sxbp_bitmap_t data type.
+ * This compilation unit provides unit tests for the sxbp_Bitmap data type.
  *
  * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
  *
@@ -23,7 +23,7 @@
 
 
 START_TEST(test_blank_bitmap) {
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    sxbp_Bitmap bitmap = sxbp_blank_bitmap();
 
     // bitmap returned should have all fields set to zero/blank values
     ck_assert(bitmap.width == 0);
@@ -32,18 +32,18 @@ START_TEST(test_blank_bitmap) {
 } END_TEST
 
 START_TEST(test_init_bitmap) {
-    sxbp_bitmap_t bitmap = { .width = 32, .height = 64, .pixels = NULL, };
+    sxbp_Bitmap bitmap = { .width = 32, .height = 64, .pixels = NULL, };
 
-    sxbp_result_t result = sxbp_init_bitmap(&bitmap);
+    sxbp_Result result = sxbp_init_bitmap(&bitmap);
 
     // check memory was allocated
     ck_assert(result == SXBP_RESULT_OK);
     ck_assert_ptr_nonnull(bitmap.pixels);
     // check all columns were allocated
-    for (sxbp_figure_size_t x = 0; x < bitmap.width; x++) {
+    for (sxbp_FigureSize x = 0; x < bitmap.width; x++) {
         ck_assert_ptr_nonnull(bitmap.pixels[x]);
         // each pixel should be 'false'
-        for (sxbp_figure_size_t y = 0; y < bitmap.height; y++) {
+        for (sxbp_FigureSize y = 0; y < bitmap.height; y++) {
             ck_assert(bitmap.pixels[x][y] == false);
         }
     }
@@ -53,16 +53,16 @@ START_TEST(test_init_bitmap) {
 } END_TEST
 
 START_TEST(test_init_bitmap_null) {
-    sxbp_result_t result = sxbp_init_bitmap(NULL);
+    sxbp_Result result = sxbp_init_bitmap(NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_init_bitmap_blank) {
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    sxbp_Bitmap bitmap = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_init_bitmap(&bitmap);
+    sxbp_Result result = sxbp_init_bitmap(&bitmap);
 
     // return code should be 'not implemented'
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
@@ -71,9 +71,9 @@ START_TEST(test_init_bitmap_blank) {
 } END_TEST
 
 START_TEST(test_init_bitmap_width_zero) {
-    sxbp_bitmap_t bitmap = { .width = 0, .height = 32, .pixels = NULL, };
+    sxbp_Bitmap bitmap = { .width = 0, .height = 32, .pixels = NULL, };
 
-    sxbp_result_t result = sxbp_init_bitmap(&bitmap);
+    sxbp_Result result = sxbp_init_bitmap(&bitmap);
 
     // return code should be 'not implemented'
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
@@ -82,9 +82,9 @@ START_TEST(test_init_bitmap_width_zero) {
 } END_TEST
 
 START_TEST(test_init_bitmap_height_zero) {
-    sxbp_bitmap_t bitmap = { .width = 32, .height = 0, .pixels = NULL, };
+    sxbp_Bitmap bitmap = { .width = 32, .height = 0, .pixels = NULL, };
 
-    sxbp_result_t result = sxbp_init_bitmap(&bitmap);
+    sxbp_Result result = sxbp_init_bitmap(&bitmap);
 
     // return code should be 'not implemented'
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
@@ -93,7 +93,7 @@ START_TEST(test_init_bitmap_height_zero) {
 } END_TEST
 
 START_TEST(test_free_bitmap_unallocated) {
-    sxbp_bitmap_t bitmap = sxbp_blank_bitmap();
+    sxbp_Bitmap bitmap = sxbp_blank_bitmap();
 
     /*
      * it should be possible to safely call the freeing function on an
@@ -108,7 +108,7 @@ START_TEST(test_free_bitmap_unallocated) {
 } END_TEST
 
 START_TEST(test_free_bitmap_allocated) {
-    sxbp_bitmap_t bitmap = { .width = 32, .height = 64, .pixels = NULL, };
+    sxbp_Bitmap bitmap = { .width = 32, .height = 64, .pixels = NULL, };
     /*
      * allocate the bitmap -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -127,7 +127,7 @@ START_TEST(test_free_bitmap_allocated) {
 } END_TEST
 
 START_TEST(test_copy_bitmap) {
-    sxbp_bitmap_t from = { .width = 32, .height = 64, .pixels = NULL, };
+    sxbp_Bitmap from = { .width = 32, .height = 64, .pixels = NULL, };
     /*
      * allocate the bitmap -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -136,15 +136,15 @@ START_TEST(test_copy_bitmap) {
         ck_abort_msg("Unable to allocate bitmap");
     }
     // populate the bitmap with random pixels
-    for (sxbp_figure_size_t x = 0; x < from.width; x++) {
-        for (sxbp_figure_size_t y = 0; y < from.height; y++) {
+    for (sxbp_FigureSize x = 0; x < from.width; x++) {
+        for (sxbp_FigureSize y = 0; y < from.height; y++) {
             from.pixels[x][y] = rand() % 2;
         }
     }
     // this is the destination bitmap to copy to
-    sxbp_bitmap_t to = sxbp_blank_bitmap();
+    sxbp_Bitmap to = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(&from, &to);
+    sxbp_Result result = sxbp_copy_bitmap(&from, &to);
 
     // check operation was successful
     ck_assert(result == SXBP_RESULT_OK);
@@ -153,8 +153,8 @@ START_TEST(test_copy_bitmap) {
     // check that contents are actually identical
     ck_assert(to.width == from.width);
     ck_assert(to.height == from.height);
-    for (sxbp_figure_size_t x = 0; x < to.width; x++) {
-        for (sxbp_figure_size_t y = 0; y < to.height; y++) {
+    for (sxbp_FigureSize x = 0; x < to.width; x++) {
+        for (sxbp_FigureSize y = 0; y < to.height; y++) {
             ck_assert(to.pixels[x][y] == from.pixels[x][y]);
         }
     }
@@ -165,28 +165,28 @@ START_TEST(test_copy_bitmap) {
 } END_TEST
 
 START_TEST(test_copy_bitmap_from_null) {
-    sxbp_bitmap_t to = sxbp_blank_bitmap();
+    sxbp_Bitmap to = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(NULL, &to);
+    sxbp_Result result = sxbp_copy_bitmap(NULL, &to);
 
     // precondition check error should be returned when from is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_copy_bitmap_to_null) {
-    sxbp_bitmap_t from = sxbp_blank_bitmap();
+    sxbp_Bitmap from = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(&from, NULL);
+    sxbp_Result result = sxbp_copy_bitmap(&from, NULL);
 
     // precondition check error should be returned when to is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_copy_bitmap_blank) {
-    sxbp_bitmap_t from = sxbp_blank_bitmap();
-    sxbp_bitmap_t to = sxbp_blank_bitmap();
+    sxbp_Bitmap from = sxbp_blank_bitmap();
+    sxbp_Bitmap to = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(&from, &to);
+    sxbp_Result result = sxbp_copy_bitmap(&from, &to);
 
     /*
      * it should be possible to successfully 'copy' a blank bitmap, with the
@@ -201,14 +201,14 @@ START_TEST(test_copy_bitmap_blank) {
 } END_TEST
 
 START_TEST(test_copy_bitmap_pixels_null) {
-    sxbp_bitmap_t from = {
+    sxbp_Bitmap from = {
         .width = 32,
         .height = 32,
         .pixels = NULL,
     };
-    sxbp_bitmap_t to = sxbp_blank_bitmap();
+    sxbp_Bitmap to = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(&from, &to);
+    sxbp_Result result = sxbp_copy_bitmap(&from, &to);
 
     /*
      * if the source has non-zero size but pixels are NULL, a precondition
@@ -220,14 +220,14 @@ START_TEST(test_copy_bitmap_pixels_null) {
 } END_TEST
 
 START_TEST(test_copy_bitmap_width_zero_only) {
-    sxbp_bitmap_t from = {
+    sxbp_Bitmap from = {
         .width = 0,
         .height = 32,
         .pixels = NULL,
     };
-    sxbp_bitmap_t to = sxbp_blank_bitmap();
+    sxbp_Bitmap to = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(&from, &to);
+    sxbp_Result result = sxbp_copy_bitmap(&from, &to);
 
     // the return code should be success
     ck_assert(result == SXBP_RESULT_OK);
@@ -236,14 +236,14 @@ START_TEST(test_copy_bitmap_width_zero_only) {
 } END_TEST
 
 START_TEST(test_copy_bitmap_height_zero_only) {
-    sxbp_bitmap_t from = {
+    sxbp_Bitmap from = {
         .width = 32,
         .height = 0,
         .pixels = NULL,
     };
-    sxbp_bitmap_t to = sxbp_blank_bitmap();
+    sxbp_Bitmap to = sxbp_blank_bitmap();
 
-    sxbp_result_t result = sxbp_copy_bitmap(&from, &to);
+    sxbp_Result result = sxbp_copy_bitmap(&from, &to);
 
     // the return code should be success
     ck_assert(result == SXBP_RESULT_OK);
@@ -252,7 +252,7 @@ START_TEST(test_copy_bitmap_height_zero_only) {
 } END_TEST
 
 START_TEST(test_copy_bitmap_to_itself) {
-    sxbp_bitmap_t bitmap = { .width = 32, .height = 64, .pixels = NULL, };
+    sxbp_Bitmap bitmap = { .width = 32, .height = 64, .pixels = NULL, };
     /*
      * allocate the bitmap -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -261,8 +261,8 @@ START_TEST(test_copy_bitmap_to_itself) {
         ck_abort_msg("Unable to allocate bitmap");
     }
     // populate the bitmap with random pixels
-    for (sxbp_figure_size_t x = 0; x < bitmap.width; x++) {
-        for (sxbp_figure_size_t y = 0; y < bitmap.height; y++) {
+    for (sxbp_FigureSize x = 0; x < bitmap.width; x++) {
+        for (sxbp_FigureSize y = 0; y < bitmap.height; y++) {
             bitmap.pixels[x][y] = rand() % 2;
         }
     }
@@ -270,7 +270,7 @@ START_TEST(test_copy_bitmap_to_itself) {
     bool** pixels = bitmap.pixels;
 
     // try and copy the bitmap to itself
-    sxbp_result_t result = sxbp_copy_bitmap(&bitmap, &bitmap);
+    sxbp_Result result = sxbp_copy_bitmap(&bitmap, &bitmap);
 
     // not implemented error code should be returned
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);

--- a/tests/test_buffer.c
+++ b/tests/test_buffer.c
@@ -2,7 +2,7 @@
  * This source file forms part of sxbp, a library which generates experimental
  * 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides unit tests for the sxbp_buffer_t data type.
+ * This compilation unit provides unit tests for the sxbp_Buffer data type.
  *
  * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
  *
@@ -51,7 +51,7 @@ static void tear_down(void) {
 }
 
 START_TEST(test_blank_buffer) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
     // buffer returned should have all fields set to zero/blank values
     ck_assert(buffer.size == 0);
@@ -59,12 +59,12 @@ START_TEST(test_blank_buffer) {
 } END_TEST
 
 START_TEST(test_init_buffer) {
-    sxbp_buffer_t buffer = {
+    sxbp_Buffer buffer = {
         .bytes = NULL,
         .size = 10000,
     };
 
-    sxbp_result_t result = sxbp_init_buffer(&buffer);
+    sxbp_Result result = sxbp_init_buffer(&buffer);
 
     // check memory was allocated
     ck_assert(result == SXBP_RESULT_OK);
@@ -78,23 +78,23 @@ START_TEST(test_init_buffer) {
 } END_TEST
 
 START_TEST(test_init_buffer_null) {
-    sxbp_result_t result = sxbp_init_buffer(NULL);
+    sxbp_Result result = sxbp_init_buffer(NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_init_buffer_blank) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_init_buffer(&buffer);
+    sxbp_Result result = sxbp_init_buffer(&buffer);
 
     // check that the return code was a 'not implemented' error
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
 } END_TEST
 
 START_TEST(test_free_buffer_unallocated) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
     /*
      * it should be possible to safely call the freeing function on an
@@ -109,7 +109,7 @@ START_TEST(test_free_buffer_unallocated) {
 } END_TEST
 
 START_TEST(test_free_buffer_allocated) {
-    sxbp_buffer_t buffer = { .size = 10000, .bytes = NULL, };
+    sxbp_Buffer buffer = { .size = 10000, .bytes = NULL, };
     /*
      * allocate the buffer -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -128,7 +128,7 @@ START_TEST(test_free_buffer_allocated) {
 } END_TEST
 
 START_TEST(test_copy_buffer) {
-    sxbp_buffer_t from = { .size = 10000, .bytes = NULL, };
+    sxbp_Buffer from = { .size = 10000, .bytes = NULL, };
     /*
      * allocate the buffer -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -141,9 +141,9 @@ START_TEST(test_copy_buffer) {
         from.bytes[i] = rand() & 0xff;
     }
     // this is the destination buffer to copy to
-    sxbp_buffer_t to = sxbp_blank_buffer();
+    sxbp_Buffer to = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_copy_buffer(&from, &to);
+    sxbp_Result result = sxbp_copy_buffer(&from, &to);
 
     // check operation was successful
     ck_assert(result == SXBP_RESULT_OK);
@@ -161,28 +161,28 @@ START_TEST(test_copy_buffer) {
 } END_TEST
 
 START_TEST(test_copy_buffer_from_null) {
-    sxbp_buffer_t to = sxbp_blank_buffer();
+    sxbp_Buffer to = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_copy_buffer(NULL, &to);
+    sxbp_Result result = sxbp_copy_buffer(NULL, &to);
 
     // precondition check error should be returned when from is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_copy_buffer_to_null) {
-    sxbp_buffer_t from = sxbp_blank_buffer();
+    sxbp_Buffer from = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_copy_buffer(&from, NULL);
+    sxbp_Result result = sxbp_copy_buffer(&from, NULL);
 
     // precondition check error should be returned when to is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_copy_buffer_blank) {
-    sxbp_buffer_t from = sxbp_blank_buffer();
-    sxbp_buffer_t to = sxbp_blank_buffer();
+    sxbp_Buffer from = sxbp_blank_buffer();
+    sxbp_Buffer to = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_copy_buffer(&from, &to);
+    sxbp_Result result = sxbp_copy_buffer(&from, &to);
 
     /*
      * it should be possible to successfully 'copy' a blank buffer, with the
@@ -196,13 +196,13 @@ START_TEST(test_copy_buffer_blank) {
 } END_TEST
 
 START_TEST(test_copy_buffer_bytes_null) {
-    sxbp_buffer_t from = {
+    sxbp_Buffer from = {
         .size = 32,
         .bytes = NULL,
     };
-    sxbp_buffer_t to = sxbp_blank_buffer();
+    sxbp_Buffer to = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_copy_buffer(&from, &to);
+    sxbp_Result result = sxbp_copy_buffer(&from, &to);
 
     /*
      * if the source has non-zero size but bytes are NULL, a precondition
@@ -214,7 +214,7 @@ START_TEST(test_copy_buffer_bytes_null) {
 } END_TEST
 
 START_TEST(test_copy_buffer_to_itself) {
-    sxbp_buffer_t buffer = { .size = 10000, .bytes = NULL, };
+    sxbp_Buffer buffer = { .size = 10000, .bytes = NULL, };
     /*
      * allocate the buffer -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -230,7 +230,7 @@ START_TEST(test_copy_buffer_to_itself) {
     uint8_t* bytes = buffer.bytes;
 
     // try and copy the buffer to itself
-    sxbp_result_t result = sxbp_copy_buffer(&buffer, &buffer);
+    sxbp_Result result = sxbp_copy_buffer(&buffer, &buffer);
 
     // not implemented error code should be returned
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
@@ -250,10 +250,10 @@ START_TEST(test_buffer_from_file) {
         ck_abort_msg("Unable to open test file in read mode");
     }
     // create a buffer to read the file into
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
     // try and read the file into the buffer
-    sxbp_result_t result = sxbp_buffer_from_file(temp_file, &buffer);
+    sxbp_Result result = sxbp_buffer_from_file(temp_file, &buffer);
 
     // assert that the operation was successful
     ck_assert(result == SXBP_RESULT_OK);
@@ -268,9 +268,9 @@ START_TEST(test_buffer_from_file) {
 } END_TEST
 
 START_TEST(test_buffer_from_file_file_null) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_buffer_from_file(NULL, &buffer);
+    sxbp_Result result = sxbp_buffer_from_file(NULL, &buffer);
 
     // result should be precondition failure
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -285,7 +285,7 @@ START_TEST(test_buffer_from_file_buffer_null) {
     if (temp_file == NULL) {
         ck_abort_msg("Unable to open test file in read mode");
     }
-    sxbp_result_t result = sxbp_buffer_from_file(temp_file, NULL);
+    sxbp_Result result = sxbp_buffer_from_file(temp_file, NULL);
 
     // result should be precondition failure
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);

--- a/tests/test_figure.c
+++ b/tests/test_figure.c
@@ -2,7 +2,7 @@
  * This source file forms part of sxbp, a library which generates experimental
  * 2D spiral-like shapes based on input binary data.
  *
- * This compilation unit provides unit tests for the sxbp_figure_t data type.
+ * This compilation unit provides unit tests for the sxbp_Figure data type.
  *
  * Copyright (C) Joshua Saxby <joshua.a.saxby@gmail.com> 2016-2017, 2018
  *
@@ -26,7 +26,7 @@
 static const uint8_t SAMPLE_SEED = 0x6D;
 static const size_t SAMPLE_FIGURE_SIZE = 9;
 
-static const sxbp_line_t SAMPLE_FIGURE_LINES[] = {
+static const sxbp_Line SAMPLE_FIGURE_LINES[] = {
     { .direction = SXBP_UP, .length = 1, },
     { .direction = SXBP_RIGHT, .length = 1, },
     { .direction = SXBP_UP, .length = 1, },
@@ -38,7 +38,7 @@ static const sxbp_line_t SAMPLE_FIGURE_LINES[] = {
     { .direction = SXBP_DOWN, .length = 1, },
 };
 
-static const sxbp_line_t REFINED_SAMPLE_FIGURE_LINES[] = {
+static const sxbp_Line REFINED_SAMPLE_FIGURE_LINES[] = {
     { .direction = SXBP_UP, .length = 1, },
     { .direction = SXBP_RIGHT, .length = 1, },
     { .direction = SXBP_UP, .length = 1, },
@@ -134,7 +134,7 @@ static const uint8_t SAMPLE_SVG_FILE_DATA[] = {
 };
 
 START_TEST(test_blank_figure) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
     // figure returned should have all fields set to zero/blank values
     ck_assert(figure.size == 0);
@@ -143,13 +143,13 @@ START_TEST(test_blank_figure) {
 } END_TEST
 
 START_TEST(test_init_figure) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = 100,
         .lines = NULL,
         .lines_remaining = 0,
     };
 
-    sxbp_result_t result = sxbp_init_figure(&figure);
+    sxbp_Result result = sxbp_init_figure(&figure);
 
     // check memory was allocated
     ck_assert(result == SXBP_RESULT_OK);
@@ -164,23 +164,23 @@ START_TEST(test_init_figure) {
 } END_TEST
 
 START_TEST(test_init_figure_null) {
-    sxbp_result_t result = sxbp_init_figure(NULL);
+    sxbp_Result result = sxbp_init_figure(NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_init_figure_blank) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_init_figure(&figure);
+    sxbp_Result result = sxbp_init_figure(&figure);
 
     // check that the return code was a 'not implemented' error
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
 } END_TEST
 
 START_TEST(test_free_figure_unallocated) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
     /*
      * it should be possible to safely call the freeing function on an
@@ -195,7 +195,7 @@ START_TEST(test_free_figure_unallocated) {
 } END_TEST
 
 START_TEST(test_free_figure_allocated) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = 100,
         .lines = NULL,
         .lines_remaining = 0,
@@ -218,7 +218,7 @@ START_TEST(test_free_figure_allocated) {
 } END_TEST
 
 START_TEST(test_copy_figure) {
-    sxbp_figure_t from = {
+    sxbp_Figure from = {
         .size = 100,
         .lines = NULL,
         .lines_remaining = 0,
@@ -236,9 +236,9 @@ START_TEST(test_copy_figure) {
         from.lines[i].length = rand() & 0x3fffffff; // range 0..2^30
     }
     // this is the destination figure to copy to
-    sxbp_figure_t to = sxbp_blank_figure();
+    sxbp_Figure to = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_copy_figure(&from, &to);
+    sxbp_Result result = sxbp_copy_figure(&from, &to);
 
     // check operation was successful
     ck_assert(result == SXBP_RESULT_OK);
@@ -258,28 +258,28 @@ START_TEST(test_copy_figure) {
 } END_TEST
 
 START_TEST(test_copy_figure_from_null) {
-    sxbp_figure_t to = sxbp_blank_figure();
+    sxbp_Figure to = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_copy_figure(NULL, &to);
+    sxbp_Result result = sxbp_copy_figure(NULL, &to);
 
     // precondition check error should be returned when from is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_copy_figure_to_null) {
-    sxbp_figure_t from = sxbp_blank_figure();
+    sxbp_Figure from = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_copy_figure(&from, NULL);
+    sxbp_Result result = sxbp_copy_figure(&from, NULL);
 
     // precondition check error should be returned when to is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_copy_figure_blank) {
-    sxbp_figure_t from = sxbp_blank_figure();
-    sxbp_figure_t to = sxbp_blank_figure();
+    sxbp_Figure from = sxbp_blank_figure();
+    sxbp_Figure to = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_copy_figure(&from, &to);
+    sxbp_Result result = sxbp_copy_figure(&from, &to);
 
     /*
      * it should be possible to successfully 'copy' a blank figure, with the
@@ -294,14 +294,14 @@ START_TEST(test_copy_figure_blank) {
 } END_TEST
 
 START_TEST(test_copy_figure_lines_null) {
-    sxbp_figure_t from = {
+    sxbp_Figure from = {
         .size = 32,
         .lines = NULL,
         .lines_remaining = 0,
     };
-    sxbp_figure_t to = sxbp_blank_figure();
+    sxbp_Figure to = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_copy_figure(&from, &to);
+    sxbp_Result result = sxbp_copy_figure(&from, &to);
 
     /*
      * if the source has non-zero size but lines are NULL, a precondition
@@ -313,7 +313,7 @@ START_TEST(test_copy_figure_lines_null) {
 } END_TEST
 
 START_TEST(test_copy_figure_to_itself) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = 100,
         .lines = NULL,
         .lines_remaining = 0,
@@ -331,10 +331,10 @@ START_TEST(test_copy_figure_to_itself) {
         figure.lines[i].length = rand() & 0x3fffffff; // range 0..2^30
     }
     // store lines pointer for checking later
-    sxbp_line_t* lines = figure.lines;
+    sxbp_Line* lines = figure.lines;
 
     // try and copy the figure to itself
-    sxbp_result_t result = sxbp_copy_figure(&figure, &figure);
+    sxbp_Result result = sxbp_copy_figure(&figure, &figure);
 
     // not implemented error code should be returned
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
@@ -348,7 +348,7 @@ START_TEST(test_copy_figure_to_itself) {
 } END_TEST
 
 START_TEST(test_begin_figure) {
-    sxbp_buffer_t buffer = { .size = 1, .bytes = NULL, };
+    sxbp_Buffer buffer = { .size = 1, .bytes = NULL, };
     /*
      * allocate the buffer -if this fails then we'll abort here because this
      * test case is not testing the init function
@@ -359,9 +359,9 @@ START_TEST(test_begin_figure) {
     // populate our one byte -this 'seed' should generate our sample lines
     buffer.bytes[0] = SAMPLE_SEED;
     // create a blank figure to write the created figure into
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_begin_figure(&buffer, NULL, &figure);
+    sxbp_Result result = sxbp_begin_figure(&buffer, NULL, &figure);
 
     // check the result was success
     ck_assert(result == SXBP_RESULT_OK);
@@ -381,7 +381,7 @@ START_TEST(test_begin_figure) {
 
 START_TEST(test_begin_figure_data_too_big) {
     // create a buffer that is larger than SXBP_BEGIN_BUFFER_MAX_SIZE
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
     buffer.size = SXBP_BEGIN_BUFFER_MAX_SIZE + 1;
     /*
      * allocate the buffer -if this fails then we'll abort here because this
@@ -390,9 +390,9 @@ START_TEST(test_begin_figure_data_too_big) {
     if (sxbp_init_buffer(&buffer) != SXBP_RESULT_OK) {
         ck_abort_msg("Unable to allocate buffer");
     }
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_begin_figure(&buffer, NULL, &figure);
+    sxbp_Result result = sxbp_begin_figure(&buffer, NULL, &figure);
 
     // precondition check error should be returned when data is too big
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -402,9 +402,9 @@ START_TEST(test_begin_figure_data_too_big) {
 } END_TEST
 
 START_TEST(test_begin_figure_data_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_begin_figure(NULL, NULL, &figure);
+    sxbp_Result result = sxbp_begin_figure(NULL, NULL, &figure);
 
     // precondition check error should be returned when data is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -412,7 +412,7 @@ START_TEST(test_begin_figure_data_null) {
 
 START_TEST(test_begin_figure_figure_null) {
     // create a buffer that
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
     buffer.size = 100;
     /*
      * allocate the buffer -if this fails then we'll abort here because this
@@ -422,7 +422,7 @@ START_TEST(test_begin_figure_figure_null) {
         ck_abort_msg("Unable to allocate buffer");
     }
 
-    sxbp_result_t result = sxbp_begin_figure(&buffer, NULL, NULL);
+    sxbp_Result result = sxbp_begin_figure(&buffer, NULL, NULL);
 
     // precondition check error should be returned when figure is NULL
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -432,7 +432,7 @@ START_TEST(test_begin_figure_figure_null) {
 } END_TEST
 
 START_TEST(test_refine_figure) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = SAMPLE_FIGURE_SIZE,
         .lines = NULL,
         .lines_remaining = 0,
@@ -449,7 +449,7 @@ START_TEST(test_refine_figure) {
         figure.lines[i] = SAMPLE_FIGURE_LINES[i];
     }
 
-    sxbp_result_t result = sxbp_refine_figure(&figure, NULL);
+    sxbp_Result result = sxbp_refine_figure(&figure, NULL);
 
     // check the operation was successful
     ck_assert(result == SXBP_RESULT_OK);
@@ -473,7 +473,7 @@ START_TEST(test_refine_figure) {
 } END_TEST
 
 START_TEST(test_refine_figure_figure_null) {
-    sxbp_result_t result = sxbp_refine_figure(NULL, NULL);
+    sxbp_Result result = sxbp_refine_figure(NULL, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -481,9 +481,9 @@ START_TEST(test_refine_figure_figure_null) {
 
 START_TEST(test_refine_figure_no_lines) {
     // create a figure with no lines
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_refine_figure(&figure, NULL);
+    sxbp_Result result = sxbp_refine_figure(&figure, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -491,7 +491,7 @@ START_TEST(test_refine_figure_no_lines) {
 
 START_TEST(test_refine_figure_unimplemented_method) {
     // make a figure with some lines, but we don't care what they are
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = 100,
         .lines = NULL,
         .lines_remaining = 0,
@@ -504,13 +504,13 @@ START_TEST(test_refine_figure_unimplemented_method) {
         ck_abort_msg("Unable to allocate figure");
     }
     // specify an unimplemented refinement method
-    sxbp_refine_figure_options_t options = {
+    sxbp_RefineFigureOptions options = {
         .refine_method = SXBP_REFINE_METHOD_RESERVED_END,
         .progress_callback = NULL,
         .callback_context = NULL,
     };
 
-    sxbp_result_t result = sxbp_refine_figure(&figure, &options);
+    sxbp_Result result = sxbp_refine_figure(&figure, &options);
 
     // check that the return code was a not-implemented error
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
@@ -520,7 +520,7 @@ START_TEST(test_refine_figure_unimplemented_method) {
 } END_TEST
 
 START_TEST(test_dump_figure) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = SAMPLE_FIGURE_SIZE,
         .lines = NULL,
         .lines_remaining = 0,
@@ -537,9 +537,9 @@ START_TEST(test_dump_figure) {
         figure.lines[i] = SAMPLE_FIGURE_LINES[i];
     }
     // we'll try and dump the figure into here
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_dump_figure(&figure, &buffer);
+    sxbp_Result result = sxbp_dump_figure(&figure, &buffer);
 
     // check that the operation completed successfully
     ck_assert(result == SXBP_RESULT_OK);
@@ -554,25 +554,25 @@ START_TEST(test_dump_figure) {
 } END_TEST
 
 START_TEST(test_dump_figure_figure_null) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_dump_figure(NULL, &buffer);
+    sxbp_Result result = sxbp_dump_figure(NULL, &buffer);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_dump_figure_buffer_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_dump_figure(&figure, NULL);
+    sxbp_Result result = sxbp_dump_figure(&figure, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_load_figure) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
     buffer.size = sizeof(SAMPLE_SXBP_FILE_DATA);
     /*
      * allocate the buffer -if this fails then we'll abort here because this
@@ -585,9 +585,9 @@ START_TEST(test_load_figure) {
     for (size_t i = 0; i < buffer.size; i++) {
         buffer.bytes[i] = SAMPLE_SXBP_FILE_DATA[i];
     }
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_load_figure(&buffer, &figure);
+    sxbp_Result result = sxbp_load_figure(&buffer, &figure);
 
     // check the operation completed successfully
     ck_assert(result == SXBP_RESULT_OK);
@@ -604,18 +604,18 @@ START_TEST(test_load_figure) {
 } END_TEST
 
 START_TEST(test_load_figure_buffer_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_load_figure(NULL, &figure);
+    sxbp_Result result = sxbp_load_figure(NULL, &figure);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_load_figure_figure_null) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_load_figure(&buffer, NULL);
+    sxbp_Result result = sxbp_load_figure(&buffer, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
@@ -632,9 +632,9 @@ START_TEST(test_load_figure_figure_null) {
 struct test_render_figure_custom_options { const char* foo; };
 
 // global variables for test_render_figure test case
-static sxbp_figure_t test_render_figure_figure;
-static sxbp_buffer_t test_render_figure_buffer;
-static sxbp_render_options_t test_render_figure_render_options;
+static sxbp_Figure test_render_figure_figure;
+static sxbp_Buffer test_render_figure_buffer;
+static sxbp_RenderOptions test_render_figure_render_options;
 static struct test_render_figure_custom_options test_render_figure_custom_options = {
     .foo = "bar",
 };
@@ -643,10 +643,10 @@ static struct test_render_figure_custom_options test_render_figure_custom_option
  * a dummy renderer backend which doesn't render anything at all, but which
  * asserts that its arguments match the global variables declared above
  */
-static sxbp_result_t unit_test_renderer_backend(
-    const sxbp_figure_t* const figure,
-    sxbp_buffer_t* const buffer,
-    const sxbp_render_options_t* const render_options,
+static sxbp_Result unit_test_renderer_backend(
+    const sxbp_Figure* const figure,
+    sxbp_Buffer* const buffer,
+    const sxbp_RenderOptions* const render_options,
     const void* render_callback_options
 ) {
     // given arguments should match the global variables above
@@ -675,7 +675,7 @@ START_TEST(test_render_figure) {
     test_render_figure_buffer = sxbp_blank_buffer();
     test_render_figure_render_options.scale = 1;
 
-    sxbp_result_t result = sxbp_render_figure(
+    sxbp_Result result = sxbp_render_figure(
         &test_render_figure_figure,
         &test_render_figure_buffer,
         unit_test_renderer_backend,
@@ -692,9 +692,9 @@ START_TEST(test_render_figure) {
 } END_TEST
 
 START_TEST(test_render_figure_figure_null) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_render_figure(
+    sxbp_Result result = sxbp_render_figure(
         NULL,
         &buffer,
         sxbp_render_figure_to_null, // just pass it the dummy backend
@@ -707,9 +707,9 @@ START_TEST(test_render_figure_figure_null) {
 } END_TEST
 
 START_TEST(test_render_figure_buffer_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_render_figure(
+    sxbp_Result result = sxbp_render_figure(
         &figure,
         NULL,
         sxbp_render_figure_to_null, // just pass it the dummy backend
@@ -722,10 +722,10 @@ START_TEST(test_render_figure_buffer_null) {
 } END_TEST
 
 START_TEST(test_render_figure_render_callback_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Figure figure = sxbp_blank_figure();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_render_figure(
+    sxbp_Result result = sxbp_render_figure(
         &figure,
         &buffer,
         NULL, // make sure to not pass any render backend
@@ -739,14 +739,14 @@ START_TEST(test_render_figure_render_callback_null) {
 
 START_TEST(test_render_figure_to_null) {
     // this function doesn't care if no objects are passed to it
-    sxbp_result_t result = sxbp_render_figure_to_null(NULL, NULL, NULL, NULL);
+    sxbp_Result result = sxbp_render_figure_to_null(NULL, NULL, NULL, NULL);
 
     // this function should always return the not-implemented error code
     ck_assert(result == SXBP_RESULT_FAIL_UNIMPLEMENTED);
 } END_TEST
 
 START_TEST(test_render_figure_to_pbm) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = SAMPLE_FIGURE_SIZE,
         .lines = NULL,
         .lines_remaining = 0,
@@ -763,9 +763,9 @@ START_TEST(test_render_figure_to_pbm) {
         figure.lines[i] = REFINED_SAMPLE_FIGURE_LINES[i];
     }
     // the buffer we'll render the PBM file into
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
     // read into another buffer the expected PBM file data
-    sxbp_buffer_t expected = sxbp_blank_buffer();
+    sxbp_Buffer expected = sxbp_blank_buffer();
     expected.size = sizeof(SAMPLE_PBM_FILE_DATA);
     /*
      * allocate the buffer -if this fails then we'll abort here because this
@@ -780,7 +780,7 @@ START_TEST(test_render_figure_to_pbm) {
     }
 
     // render the figure to PBM
-    sxbp_result_t result = sxbp_render_figure_to_pbm(
+    sxbp_Result result = sxbp_render_figure_to_pbm(
         &figure,
         &buffer,
         NULL,
@@ -800,25 +800,25 @@ START_TEST(test_render_figure_to_pbm) {
 } END_TEST
 
 START_TEST(test_render_figure_to_pbm_figure_null) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_render_figure_to_pbm(NULL, &buffer, NULL, NULL);
+    sxbp_Result result = sxbp_render_figure_to_pbm(NULL, &buffer, NULL, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_render_figure_to_pbm_buffer_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_render_figure_to_pbm(&figure, NULL, NULL, NULL);
+    sxbp_Result result = sxbp_render_figure_to_pbm(&figure, NULL, NULL, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_render_figure_to_svg) {
-    sxbp_figure_t figure = {
+    sxbp_Figure figure = {
         .size = SAMPLE_FIGURE_SIZE,
         .lines = NULL,
         .lines_remaining = 0,
@@ -836,9 +836,9 @@ START_TEST(test_render_figure_to_svg) {
         figure.lines[i] = REFINED_SAMPLE_FIGURE_LINES[i];
     }
     // the buffer we'll render the SVG file into
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
     // read into another buffer the expected SVG file data
-    sxbp_buffer_t expected = sxbp_blank_buffer();
+    sxbp_Buffer expected = sxbp_blank_buffer();
     expected.size = sizeof(SAMPLE_SVG_FILE_DATA);
     /*
      * allocate the buffer -if this fails then we'll abort here because this
@@ -853,7 +853,7 @@ START_TEST(test_render_figure_to_svg) {
     }
 
     // render the figure to SVG
-    sxbp_result_t result = sxbp_render_figure_to_svg(
+    sxbp_Result result = sxbp_render_figure_to_svg(
         &figure,
         &buffer,
         NULL,
@@ -873,18 +873,18 @@ START_TEST(test_render_figure_to_svg) {
 } END_TEST
 
 START_TEST(test_render_figure_to_svg_figure_null) {
-    sxbp_buffer_t buffer = sxbp_blank_buffer();
+    sxbp_Buffer buffer = sxbp_blank_buffer();
 
-    sxbp_result_t result = sxbp_render_figure_to_svg(NULL, &buffer, NULL, NULL);
+    sxbp_Result result = sxbp_render_figure_to_svg(NULL, &buffer, NULL, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);
 } END_TEST
 
 START_TEST(test_render_figure_to_svg_buffer_null) {
-    sxbp_figure_t figure = sxbp_blank_figure();
+    sxbp_Figure figure = sxbp_blank_figure();
 
-    sxbp_result_t result = sxbp_render_figure_to_svg(&figure, NULL, NULL, NULL);
+    sxbp_Result result = sxbp_render_figure_to_svg(&figure, NULL, NULL, NULL);
 
     // check that the return code was a precondition check error
     ck_assert(result == SXBP_RESULT_FAIL_PRECONDITION);


### PR DESCRIPTION
After doing some research, I discovered that type names ending in `_t` are reserved by POSIX.

This PR alters all library type names to use `sxbp_` followed by UpperCamelCase names.